### PR TITLE
Add streaming support (sse)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImpl.kt
@@ -19,6 +19,7 @@ class AiChatRepositoryImpl @Inject constructor(
     private val chatMessageRepositoryImpl: ChatMessageRepositoryImpl,
     @Named(GEMINI) private val aiChatApi: AiChatApi,
 ) : AiChatRepository {
+
     override fun getMessageFlowForConversation(conversationId: String): Flow<List<ChatMessage>> {
         return chatMessageRepositoryImpl.getMessageFlowForConversation(conversationId)
     }
@@ -48,7 +49,7 @@ class AiChatRepositoryImpl @Inject constructor(
 
             var messageId: String? = null
             var responseSoFar = ""
-            aiChatApi.generateResponseForConversation(
+            aiChatApi.generateStreamingResponseForConversation(
                 GenerateContentRequest(contents = conversationContents)
             ).collect {
                 responseSoFar += it.candidates

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/chat/ChatMessageRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/chat/ChatMessageRepository.kt
@@ -33,10 +33,18 @@ interface ChatMessageRepository {
 
     /**
      * Modifies an existing message in the conversation.
+     *
+     * Useful for streaming conversations, where messages are
+     * updated as they are received.
+     *
+     * @param conversationId the id of the conversation
+     * @param messageId the id of the message to modify
+     * @param newText the new text of the message
+     * @return the id of the modified message
      */
     suspend fun modifyMessageFromConversation(
         conversationId: String,
         messageId: String,
         newText: String,
-    )
+    ): String
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/chat/ChatMessageRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/chat/ChatMessageRepositoryImpl.kt
@@ -16,6 +16,7 @@ import kotlin.uuid.Uuid
 class ChatMessageRepositoryImpl @Inject constructor(
     private val chatMessageDb: ChatMessageDb,
 ) : ChatMessageRepository {
+
     override fun getMessageFlowForConversation(conversationId: String): Flow<List<ChatMessage>> {
         return chatMessageDb.getMessagesForConversation(conversationId)
             .distinctUntilChanged()
@@ -28,13 +29,14 @@ class ChatMessageRepositoryImpl @Inject constructor(
         conversationId: String,
         messageId: String,
         newText: String,
-    ) {
-        withContext(Dispatchers.Default) {
+    ): String {
+        return withContext(Dispatchers.Default) {
             chatMessageDb.updateMessageContent(
                 id = messageId,
                 conversationId = conversationId,
                 newContent = newText,
             )
+            return@withContext messageId
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/db/chat/ChatMessageDb.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/db/chat/ChatMessageDb.kt
@@ -2,18 +2,31 @@ package com.duchastel.simon.solenne.db.chat
 
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Interface for the chat message database.
+ * Responsible for persisting chat messages and conversations.
+ */
 interface ChatMessageDb {
+    /**
+     * Gets all messages for a given conversation.
+     */
     fun getMessagesForConversation(
         conversationId: String,
     ): Flow<List<DbMessage>>
 
+    /**
+     * Writes a message to the database for a given conversation.
+     */
     suspend fun writeMessage(
         message: DbMessage
     )
 
+    /**
+     * Updates the content of a message for a given conversation.
+     */
     suspend fun updateMessageContent(
-        conversationId: String,
         id: String,
+        conversationId: String,
         newContent: String,
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
@@ -6,6 +6,19 @@ import kotlinx.serialization.Serializable
 
 interface AiChatApi {
     /**
+     * Sends a list of conversation messages to the AI and returns the plain text response,
+     * streamed in a list of [GenerateContentResponse] objects as they are generated.
+     * This supports multi-turn conversations with the AI.
+     *
+     * @param request The content of the conversation so far, which includes all
+     * messages in the conversation and a new message from the user for the AI to respond to.
+     * @return The AI's response as plain text
+     */
+    fun generateStreamingResponseForConversation(
+        request: GenerateContentRequest,
+    ): Flow<GenerateContentResponse>
+
+    /**
      * Sends a list of conversation messages to the AI and returns the plain text response.
      * This supports multi-turn conversations with the AI.
      *
@@ -13,9 +26,9 @@ interface AiChatApi {
      * messages in the conversation and a new message from the user for the AI to respond to.
      * @return The AI's response as plain text
      */
-    fun generateResponseForConversation(
+    suspend fun generateResponseForConversation(
         request: GenerateContentRequest,
-    ): Flow<GenerateContentResponse>
+    ): GenerateContentResponse
 }
 
 @Serializable

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ChatMessageRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ChatMessageRepositoryImplTest.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import com.duchastel.simon.solenne.data.chat.toChatMessage
 
 internal class ChatMessageRepositoryImplTest {
 
@@ -92,5 +94,52 @@ internal class ChatMessageRepositoryImplTest {
             assertEquals("hello there", userMsg.content)
         }
     }
-}
 
+    @Test
+    fun `DbMessage toChatMessage - User maps correctly`() {
+        val id = "1"
+        val content = "hello"
+        val dbMessage = DbMessage(
+            id = id,
+            conversationId = "conv",
+            author = 0L,
+            content = content,
+            timestamp = 0L
+        )
+        val chatMessage = dbMessage.toChatMessage()
+        assertEquals(id, chatMessage.id)
+        assertEquals(content, chatMessage.text)
+        assertEquals(MessageAuthor.User, chatMessage.author)
+    }
+
+    @Test
+    fun `DbMessage toChatMessage - AI maps correctly`() {
+        val id = "2"
+        val content = "hi from AI"
+        val dbMessage = DbMessage(
+            id = id,
+            conversationId = "conv",
+            author = 1L,
+            content = content,
+            timestamp = 0L
+        )
+        val chatMessage = dbMessage.toChatMessage()
+        assertEquals(id, chatMessage.id)
+        assertEquals(content, chatMessage.text)
+        assertEquals(MessageAuthor.AI, chatMessage.author)
+    }
+
+    @Test
+    fun `DbMessage toChatMessage - unknown author throws`() {
+        val dbMessage = DbMessage(
+            id = "3",
+            conversationId = "conv",
+            author = 2L,
+            content = "unknown",
+            timestamp = 0L
+        )
+        assertFailsWith<IllegalStateException> {
+            dbMessage.toChatMessage()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
@@ -15,7 +15,23 @@ import kotlinx.coroutines.flow.flowOf
 internal class FakeAiChatApi(
     private val fakeResponse: String = "fake-ai-response"
 ) : AiChatApi {
-    override fun generateResponseForConversation(
+    
+    override suspend fun generateResponseForConversation(
+        request: GenerateContentRequest
+    ): GenerateContentResponse {
+        return GenerateContentResponse(
+            candidates = listOf(
+                Candidate(
+                    content = Content(
+                        parts = listOf(Part(fakeResponse)),
+                        role = "model"
+                    )
+                )
+            )
+        )
+    }
+    
+    override fun generateStreamingResponseForConversation(
         request: GenerateContentRequest
     ): Flow<GenerateContentResponse> {
         return flowOf(

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageDb.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageDb.kt
@@ -19,4 +19,20 @@ internal class FakeChatMessageDb(
         val currentMessages = messages.value[message.conversationId].orEmpty()
         messages.value += (message.conversationId to (currentMessages + message))
     }
+    
+    override suspend fun updateMessageContent(
+        id: String,
+        conversationId: String,
+        newContent: String
+    ) {
+        val currentMessages = messages.value[conversationId].orEmpty()
+        val updatedMessages = currentMessages.map { msg ->
+            if (msg.id == id) {
+                msg.copy(content = newContent)
+            } else {
+                msg
+            }
+        }
+        messages.value += (conversationId to updatedMessages)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageRepository.kt
@@ -4,26 +4,29 @@ import com.duchastel.simon.solenne.data.chat.ChatMessage
 import com.duchastel.simon.solenne.data.chat.ChatMessageRepository
 import com.duchastel.simon.solenne.data.chat.MessageAuthor
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 
 internal class FakeChatMessageRepository(
-    initialMessages: List<ChatMessage> = ChatMessagesFake.chatMessages,
+    private val initialMessages: List<ChatMessage> = ChatMessagesFake.chatMessages,
 ): ChatMessageRepository {
-    private val messageFlow = MutableStateFlow(initialMessages)
 
     override fun getMessageFlowForConversation(
         conversationId: String,
-    ): Flow<List<ChatMessage>> = messageFlow
+    ): Flow<List<ChatMessage>> = flowOf(initialMessages)
 
     override suspend fun addMessageToConversation(
         conversationId: String,
         author: MessageAuthor,
         text: String,
-    ) {
-        messageFlow.value += ChatMessage(
-            id = "do-not-rely-on-this-id",
-            text = text,
-            author = author,
-        )
+    ): String {
+        return "do-not-rely-on-this-id"
+    }
+
+    override suspend fun modifyMessageFromConversation(
+        conversationId: String,
+        messageId: String,
+        newText: String
+    ): String {
+        return messageId
     }
 }


### PR DESCRIPTION
Add streaming support, so that messages from the AI come in batches rather than all at once. This is useful for really long conversations, and in the future will be crucial for agentic conversations that might be very long-running.

I messed up so two additional commits are part of this that merged straight to main:
- 90a0582f4445c4dd0f6b14d272d756f07c005bb2
- 1fc605a43b3c68c7e33d4f65915f60d68b375298

_Note_ that the `httpClient.sse()` function appears to have a bug in the JS target only, so I'm using the slightly more manual  `bodyAsChannel()` function and parsing out each `data: ` message instead. The bug was that even when the stream ended, the `sse()` function would make another call to the endpoint despite no kotlin function calls being made (I checked that my code was only calling `.sse()` once).