### PR TITLE
Get API key from the UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AIModelScope.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AIModelScope.kt
@@ -1,0 +1,11 @@
+package com.duchastel.simon.solenne.data.ai
+
+sealed interface AIModelScope {
+    class GeminiModelScope internal constructor(
+        internal val apiKey: String,
+    ) : AIModelScope
+}
+
+sealed interface AIModel {
+    data object Gemini : AIModel
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepository.kt
@@ -13,10 +13,16 @@ interface AiChatRepository {
     /**
      * Gets all messages for a given conversation.
      */
-    fun getMessageFlowForConversation(conversationId: String): Flow<List<ChatMessage>>
+    fun getMessageFlowForConversation(
+        conversationId: String,
+    ): Flow<List<ChatMessage>>
 
     /**
      * Sends a text message as the user to a conversation.
      */
-    suspend fun sendTextMessageFromUserToConversation(conversationId: String, text: String)
+    suspend fun sendTextMessageFromUserToConversation(
+        aiModelScope: AIModelScope,
+        conversationId: String,
+        text: String,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/NetworkProviders.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/NetworkProviders.kt
@@ -1,5 +1,6 @@
 package com.duchastel.simon.solenne.di
 
+import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
 import com.duchastel.simon.solenne.network.ai.AiChatApi
 import com.duchastel.simon.solenne.network.ai.gemini.GEMINI
 import com.duchastel.simon.solenne.network.ai.gemini.GeminiApi
@@ -38,5 +39,5 @@ interface NetworkProviders {
 
     @Named(GEMINI)
     @Binds
-    fun GeminiApi.bind(): AiChatApi
+    fun GeminiApi.bind(): AiChatApi<GeminiModelScope>
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
@@ -1,10 +1,11 @@
 package com.duchastel.simon.solenne.network.ai
 
+import com.duchastel.simon.solenne.data.ai.AIModelScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-interface AiChatApi {
+interface AiChatApi<S> where S : AIModelScope {
     /**
      * Sends a list of conversation messages to the AI and returns the plain text response,
      * streamed in a list of [GenerateContentResponse] objects as they are generated.
@@ -15,7 +16,8 @@ interface AiChatApi {
      * @return The AI's response as plain text
      */
     fun generateStreamingResponseForConversation(
-        request: GenerateContentRequest,
+        scope: S,
+        request: GenerateContentRequest
     ): Flow<GenerateContentResponse>
 
     /**
@@ -27,6 +29,7 @@ interface AiChatApi {
      * @return The AI's response as plain text
      */
     suspend fun generateResponseForConversation(
+        scope: S,
         request: GenerateContentRequest,
     ): GenerateContentResponse
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/gemini/GeminiApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/gemini/GeminiApi.kt
@@ -1,5 +1,7 @@
 package com.duchastel.simon.solenne.network.ai.gemini
 
+import com.duchastel.simon.solenne.data.ai.AIModel.Gemini
+import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
 import com.duchastel.simon.solenne.network.JsonParser
 import com.duchastel.simon.solenne.network.ai.AiChatApi
 import com.duchastel.simon.solenne.network.ai.GenerateContentRequest
@@ -29,13 +31,13 @@ private const val MODEL_NAME = "gemini-2.0-flash"
 @Named(GEMINI)
 class GeminiApi @Inject constructor(
     private val httpClient: HttpClient,
-    private val apiKey: String = "<<YOUR_API_KEY>>",
-) : AiChatApi {
+) : AiChatApi<GeminiModelScope> {
 
     override suspend fun generateResponseForConversation(
+        scope: GeminiModelScope,
         request: GenerateContentRequest,
     ): GenerateContentResponse {
-        val url = "$BASE_URL$MODEL_NAME:generateContent?key=$apiKey"
+        val url = "$BASE_URL$MODEL_NAME:generateContent?key=${scope.apiKey}"
         val response: GenerateContentResponse = httpClient.post(url) {
             contentType(ContentType.Application.Json)
             setBody(request)
@@ -45,9 +47,10 @@ class GeminiApi @Inject constructor(
     }
 
     override fun generateStreamingResponseForConversation(
+        scope: GeminiModelScope,
         request: GenerateContentRequest,
     ): Flow<GenerateContentResponse> = channelFlow {
-        val url = "$BASE_URL$MODEL_NAME:streamGenerateContent?alt=sse&key=$apiKey"
+        val url = "$BASE_URL$MODEL_NAME:streamGenerateContent?alt=sse&key=${scope.apiKey}"
 
         httpClient.post(url){
             method = HttpMethod.Post

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
@@ -35,13 +35,8 @@ class ChatPresenter @Inject constructor(
         val coroutineScope = rememberCoroutineScope()
 
         val scope = aiModelScope
-        val messages by if (scope != null){
-            aiChatRepository.getMessageFlowForConversation(
-                screen.conversationId
-            )
-        } else {
-            flowOf(emptyList())
-        }.collectAsState(initial = emptyList())
+        val messages by aiChatRepository.getMessageFlowForConversation(screen.conversationId)
+            .collectAsState(initial = emptyList())
 
         return ChatScreen.State(
             sendButtonEnabled = aiModelScope != null && textInput.isNotBlank(),

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
@@ -18,7 +18,6 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.Inject
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
 class ChatPresenter @Inject constructor(

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
@@ -4,9 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import com.duchastel.simon.solenne.data.ai.AIModelScope
+import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
 import com.duchastel.simon.solenne.data.ai.AiChatRepository
 import com.duchastel.simon.solenne.data.chat.ChatMessage
 import com.duchastel.simon.solenne.ui.model.toUIChatMessage
@@ -15,6 +18,7 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.Inject
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 
 class ChatPresenter @Inject constructor(
@@ -24,26 +28,45 @@ class ChatPresenter @Inject constructor(
 
     @Composable
     override fun present(): ChatScreen.State {
-        val messages by aiChatRepository.getMessageFlowForConversation(screen.conversationId)
-            .collectAsState(initial = emptyList())
+        var aiModelScope: AIModelScope? by remember { mutableStateOf(null) }
+
         var textInput by rememberSaveable { mutableStateOf("") }
+        var userApiKey by rememberSaveable { mutableStateOf("") }
         val coroutineScope = rememberCoroutineScope()
 
+        val scope = aiModelScope
+        val messages by if (scope != null){
+            aiChatRepository.getMessageFlowForConversation(
+                screen.conversationId
+            )
+        } else {
+            flowOf(emptyList())
+        }.collectAsState(initial = emptyList())
+
         return ChatScreen.State(
-            saveButtonEnabled = textInput.isNotBlank(),
+            sendButtonEnabled = aiModelScope != null && textInput.isNotBlank(),
             textInput = textInput,
+            apiKey = userApiKey,
             messages = messages.map(ChatMessage::toUIChatMessage).toPersistentList(),
-        ) {
-            when (it) {
+        ) { event ->
+            when (event) {
                 is ChatScreen.Event.SendMessage -> coroutineScope.launch {
                     textInput = ""
+                    scope ?: return@launch
                     aiChatRepository.sendTextMessageFromUserToConversation(
+                        scope,
                         screen.conversationId,
-                        it.text
+                        event.text
                     )
                 }
                 is ChatScreen.Event.TextInputChanged -> {
-                    textInput = it.text
+                    textInput = event.text
+                }
+                is ChatScreen.Event.ApiKeyChanged -> {
+                    userApiKey = event.apiKey
+                }
+                is ChatScreen.Event.ApiKeySubmitted -> {
+                    aiModelScope = GeminiModelScope(userApiKey)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
@@ -15,13 +15,16 @@ data class ChatScreen(
     @Immutable
     data class State(
         val messages: PersistentList<UIChatMessage>,
-        val saveButtonEnabled: Boolean,
+        val sendButtonEnabled: Boolean,
         val textInput: String,
+        val apiKey: String,
         val eventSink: (Event) -> Unit = {},
     ): CircuitUiState
 
     sealed interface Event : CircuitUiEvent {
-        data class SendMessage(val text: String): Event
         data class TextInputChanged(val text: String): Event
+        data class SendMessage(val text: String): Event
+        data class ApiKeyChanged(val apiKey: String) : Event
+        data class ApiKeySubmitted(val apiKey: String) : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
@@ -8,14 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.data.chat.ChatMessage
 import com.duchastel.simon.solenne.fakes.ChatMessagesFake
+import com.duchastel.simon.solenne.screens.chat.ChatScreen.Event
 import com.duchastel.simon.solenne.ui.components.ChatMessage
 import com.duchastel.simon.solenne.ui.components.MessageInput
 import com.duchastel.simon.solenne.ui.model.toUIChatMessage
@@ -29,6 +26,13 @@ fun ChatUi(state: ChatScreen.State, modifier: Modifier) {
     val input = state.textInput
 
     Column(modifier = modifier.fillMaxSize()) {
+        MessageInput(
+            input = state.apiKey,
+            onInputChange = { newInput -> eventSink(Event.ApiKeyChanged(newInput)) },
+            onSend = { eventSink(Event.ApiKeySubmitted(state.apiKey)) },
+            sendEnabled = true,
+            modifier = Modifier.fillMaxWidth().padding(8.dp)
+        )
         LazyColumn(
             modifier = Modifier.weight(1f).fillMaxWidth(),
             reverseLayout = true,
@@ -40,9 +44,9 @@ fun ChatUi(state: ChatScreen.State, modifier: Modifier) {
         }
         MessageInput(
             input = input,
-            onInputChange = { newInput -> eventSink(ChatScreen.Event.TextInputChanged(newInput)) },
-            onSend = { eventSink(ChatScreen.Event.SendMessage(input)) },
-            sendEnabled = state.saveButtonEnabled,
+            onInputChange = { newInput -> eventSink(Event.TextInputChanged(newInput)) },
+            onSend = { eventSink(Event.SendMessage(input)) },
+            sendEnabled = state.sendButtonEnabled,
             modifier = Modifier.fillMaxWidth().padding(8.dp)
         )
     }
@@ -54,11 +58,12 @@ internal fun ChatUi_Preview() {
     ChatUi(
         modifier = Modifier,
         state = ChatScreen.State(
-            saveButtonEnabled = true,
+            sendButtonEnabled = true,
             textInput = "My input",
+            apiKey = "<<api-key>>",
             messages = ChatMessagesFake.chatMessages
                 .map(ChatMessage::toUIChatMessage)
-                .toPersistentList()
+                .toPersistentList(),
         )
     )
 }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import com.duchastel.simon.solenne.data.chat.MessageAuthor
 import com.duchastel.simon.solenne.db.chat.DbMessage
 import com.duchastel.simon.solenne.fakes.FakeAiChatApi
 import com.duchastel.simon.solenne.fakes.FakeChatMessageDb
+import com.duchastel.simon.solenne.fakes.FAKE_AI_MODEL_SCOPE
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -69,8 +70,6 @@ internal class AiChatRepositoryImplTest {
             assertEquals("Hello human", messages[1].text)
             assertEquals(MessageAuthor.AI, messages[1].author)
         }
-
-
     }
 
     @Test
@@ -81,7 +80,11 @@ internal class AiChatRepositoryImplTest {
 
         initRepo(aiResponse = aiResponseText)
 
-        aiChatRepo.sendTextMessageFromUserToConversation(conversationId, userMessage)
+        aiChatRepo.sendTextMessageFromUserToConversation(
+            aiModelScope = FAKE_AI_MODEL_SCOPE,
+            conversationId = conversationId,
+            text = userMessage,
+        )
 
         fakeDb.getMessagesForConversation(conversationId).test {
             val dbMessages = awaitItem()
@@ -117,7 +120,11 @@ internal class AiChatRepositoryImplTest {
             )
         )
 
-        aiChatRepo.sendTextMessageFromUserToConversation(conversationId, "Second question")
+        aiChatRepo.sendTextMessageFromUserToConversation(
+            FAKE_AI_MODEL_SCOPE,
+            conversationId,
+            "Second question",
+        )
 
         fakeDb.getMessagesForConversation(conversationId).test {
             val messages = awaitItem()

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
@@ -33,7 +33,7 @@ internal class AiChatRepositoryImplTest {
 
         aiChatRepo = AiChatRepositoryImpl(
             chatMessageRepositoryImpl = fakeChatRepo,
-            aiChatApi = fakeAiApi
+            geminiApi = fakeAiApi
         )
     }
 

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
@@ -1,5 +1,6 @@
 package com.duchastel.simon.solenne.fakes
 
+import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
 import com.duchastel.simon.solenne.network.ai.AiChatApi
 import com.duchastel.simon.solenne.network.ai.Candidate
 import com.duchastel.simon.solenne.network.ai.Content
@@ -14,9 +15,10 @@ import kotlinx.coroutines.flow.flowOf
  */
 internal class FakeAiChatApi(
     private val fakeResponse: String = "fake-ai-response"
-) : AiChatApi {
+) : AiChatApi<GeminiModelScope> {
     
     override suspend fun generateResponseForConversation(
+        scope: GeminiModelScope,
         request: GenerateContentRequest
     ): GenerateContentResponse {
         return GenerateContentResponse(
@@ -30,8 +32,9 @@ internal class FakeAiChatApi(
             )
         )
     }
-    
+
     override fun generateStreamingResponseForConversation(
+        scope: GeminiModelScope,
         request: GenerateContentRequest
     ): Flow<GenerateContentResponse> {
         return flowOf(

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatRepository.kt
@@ -1,7 +1,9 @@
 package com.duchastel.simon.solenne.fakes
 
+import com.duchastel.simon.solenne.data.ai.AIModelScope
 import com.duchastel.simon.solenne.data.ai.AiChatRepository
 import com.duchastel.simon.solenne.data.chat.ChatMessage
+import com.duchastel.simon.solenne.data.chat.MessageAuthor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -16,7 +18,14 @@ class FakeAiChatRepository(
     }
 
     override suspend fun sendTextMessageFromUserToConversation(
+        aiModelScope: AIModelScope,
         conversationId: String,
         text: String,
-    ) = Unit
+    ) {
+        conversations.value = conversations.value.toMutableMap().apply {
+            this[conversationId] = this[conversationId].orEmpty().toMutableList().apply {
+                add(ChatMessage(id = "do-not-rely-on-this-id", text = text, author = MessageAuthor.User))
+            }
+        }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiModelScope.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiModelScope.kt
@@ -1,0 +1,6 @@
+package com.duchastel.simon.solenne.fakes
+
+import com.duchastel.simon.solenne.data.ai.AIModelScope
+import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
+
+val FAKE_AI_MODEL_SCOPE: AIModelScope = GeminiModelScope("do-not-rely-on-this-fake-id")

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageDb.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeChatMessageDb.kt
@@ -19,15 +19,15 @@ internal class FakeChatMessageDb(
         val currentMessages = messages.value[message.conversationId].orEmpty()
         messages.value += (message.conversationId to (currentMessages + message))
     }
-    
+
     override suspend fun updateMessageContent(
-        id: String,
+        messageId: String,
         conversationId: String,
         newContent: String
     ) {
         val currentMessages = messages.value[conversationId].orEmpty()
         val updatedMessages = currentMessages.map { msg ->
-            if (msg.id == id) {
+            if (msg.id == messageId) {
                 msg.copy(content = newContent)
             } else {
                 msg


### PR DESCRIPTION
This adds a simple (ie. bad) UI so that you can enter the Gemini API key in the UI rather than hard-coding it into the app. This means I won't accidentally commit my Gemini API key anymore.

In the future I'll improve the UI.