### PR TITLE
Add network error handling (no UI yet)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/Errors.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/Errors.kt
@@ -1,0 +1,32 @@
+package com.duchastel.simon.solenne.network
+
+import com.duchastel.simon.solenne.util.Failure
+import com.duchastel.simon.solenne.util.SolenneResult
+import com.duchastel.simon.solenne.util.Success
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.sse.SSEClientException
+import io.modelcontextprotocol.kotlin.sdk.McpError
+import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
+
+/**
+ * Convenience function to wrap a network call made with a Ktor [HttpClient].
+ * Automatically catches and wraps any exceptions thrown by the MCP library such
+ * as [IOException] and [McpError].
+ */
+suspend fun <T> wrapHttpCall(block: suspend () -> T): SolenneResult<T> {
+    return try {
+        val successResult = block()
+        Success(successResult)
+    } catch (ex: IOException) {
+        // thrown by OkHttp when an error occurs communicating over the network
+        Failure(ex)
+    } catch (ex: SSEClientException) {
+        // thrown by OkHttp when an error occurs in the SSE HTTP stream
+        Failure(ex)
+    } catch (ex: SerializationException) {
+        // thrown by kotlinx serialization when an error occurs serializing or deserializing
+        // a network model
+        Failure(ex)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/network/ai/AiChatApi.kt
@@ -1,6 +1,8 @@
 package com.duchastel.simon.solenne.network.ai
 
 import com.duchastel.simon.solenne.data.ai.AIModelScope
+import com.duchastel.simon.solenne.util.Failure
+import com.duchastel.simon.solenne.util.SolenneResult
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -20,14 +22,16 @@ interface AiChatApi<S> where S : AIModelScope {
      * @param systemPrompt Optional system prompt to guide the AI's behavior
      * @param tools Optional list of tools the AI can use in its response
      *
-     * @return A Flow of [ConversationResponse] objects as they are generated
+     * @return A Flow of [ConversationResponse] objects wrapped in a [SolenneResult]
+     * as they are generated. If an error occurs, a [Failure] will be emitted and then
+     * no more items will be emitted.
      */
     fun generateStreamingResponseForConversation(
         scope: S,
         conversation: Conversation,
         systemPrompt: String? = null,
         tools: List<Tool> = emptyList(),
-    ): Flow<ConversationResponse>
+    ): Flow<SolenneResult<ConversationResponse>>
 
     /**
      * Sends a conversation to the AI and returns the complete response.
@@ -38,12 +42,13 @@ interface AiChatApi<S> where S : AIModelScope {
      * @param systemPrompt Optional system prompt to guide the AI's behavior
      * @param tools Optional list of tools the AI can use in its response
      *
-     * @return The AI's complete response as a [ConversationResponse]
+     * @return The AI's complete response as a [ConversationResponse] wrapped
+     * in a [SolenneResult], with a [Failure] if there was an error.
      */
     suspend fun generateResponseForConversation(
         scope: S,
         conversation: Conversation,
         systemPrompt: String? = null,
         tools: List<Tool> = emptyList(),
-    ): ConversationResponse
+    ): SolenneResult<ConversationResponse>
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/util/SolenneResult.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/util/SolenneResult.kt
@@ -61,3 +61,23 @@ inline fun <T> SolenneResult<T>.onFailure(block: (Throwable?) -> Unit): SolenneR
         is Success -> this
     }
 }
+
+/**
+ * Maps the result of this to a new type if [Success], otherwise propagates the [Failure].
+ */
+inline fun <T, R> SolenneResult<T>.map(block: (T) -> R): SolenneResult<R> {
+    return when (this) {
+        is Success -> block(this()).asSuccess()
+        is Failure -> Failure(this.error)
+    }
+}
+
+/**
+ * Returns result wrapped in a [SolenneResult] as a [Success].
+ */
+inline fun <T> T.asSuccess(): SolenneResult<T> = Success(this)
+
+/**
+ * Returns result wrapped in a [SolenneResult] as a [Failure].
+ */
+inline fun <T> Throwable?.asFailure(): SolenneResult<T> = Failure(this)

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/fakes/FakeAiChatApi.kt
@@ -8,6 +8,8 @@ import com.duchastel.simon.solenne.network.ai.Conversation
 import com.duchastel.simon.solenne.network.ai.ConversationResponse
 import com.duchastel.simon.solenne.network.ai.Message
 import com.duchastel.simon.solenne.network.ai.Tool
+import com.duchastel.simon.solenne.util.SolenneResult
+import com.duchastel.simon.solenne.util.asSuccess
 
 /**
  * A fake AiChatApi that always returns [fakeResponse], ignoring the request content.
@@ -21,13 +23,13 @@ internal class FakeAiChatApi(
         conversation: Conversation,
         systemPrompt: String?,
         tools: List<Tool>
-    ): Flow<ConversationResponse> {
+    ): Flow<SolenneResult<ConversationResponse>> {
         return flowOf(
             ConversationResponse(
                 newMessages = listOf(
                     Message.AiMessage.AiTextMessage(fakeResponse)
                 )
-            )
+            ).asSuccess()
         )
     }
 
@@ -36,11 +38,11 @@ internal class FakeAiChatApi(
         conversation: Conversation,
         systemPrompt: String?,
         tools: List<Tool>
-    ): ConversationResponse {
+    ): SolenneResult<ConversationResponse> {
         return ConversationResponse(
             newMessages = listOf(
                 Message.AiMessage.AiTextMessage(fakeResponse)
             )
-        )
+        ).asSuccess()
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/network/ai/gemini/GeminiApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/network/ai/gemini/GeminiApiTest.kt
@@ -1,0 +1,334 @@
+package com.duchastel.simon.solenne.network.ai.gemini
+
+import com.duchastel.simon.solenne.network.ai.Conversation
+import com.duchastel.simon.solenne.network.ai.ConversationResponse
+import com.duchastel.simon.solenne.network.ai.Message
+import com.duchastel.simon.solenne.network.ai.Tool
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GeminiApiTest {
+
+    @Test
+    fun `test Message UserMessage toContent`() {
+        // Given
+        val userMessage = Message.UserMessage("Hello, how are you?")
+
+        // When
+        val content = userMessage.toContent()
+
+        // Then
+        assertEquals("user", content.role)
+        assertEquals(1, content.parts.size)
+        assertEquals("Hello, how are you?", content.parts[0].text)
+        assertNull(content.parts[0].functionCall)
+    }
+
+    @Test
+    fun `test Message AiTextMessage toContent`() {
+        // Given
+        val aiMessage = Message.AiMessage.AiTextMessage("I'm doing well, thanks for asking!")
+
+        // When
+        val content = aiMessage.toContent()
+
+        // Then
+        assertEquals("model", content.role)
+        assertEquals(1, content.parts.size)
+        assertEquals("I'm doing well, thanks for asking!", content.parts[0].text)
+        assertNull(content.parts[0].functionCall)
+    }
+
+    @Test
+    fun `test Message AiToolUse toContent`() {
+        // Given
+        val arguments = mapOf(
+            "query" to JsonPrimitive("weather in San Francisco"),
+            "includeDetails" to JsonPrimitive(true)
+        )
+        val aiToolUse = Message.AiMessage.AiToolUse(
+            toolId = "search_weather",
+            argumentsSupplied = arguments
+        )
+
+        // When
+        val content = aiToolUse.toContent()
+
+        // Then
+        assertEquals("model", content.role)
+        assertEquals(1, content.parts.size)
+        assertNull(content.parts[0].text)
+        assertNotNull(content.parts[0].functionCall)
+        assertEquals("search_weather", content.parts[0].functionCall?.name)
+        assertEquals(
+            JsonPrimitive("weather in San Francisco"),
+            content.parts[0].functionCall?.args?.get("query")
+        )
+        assertEquals(
+            JsonPrimitive(true),
+            content.parts[0].functionCall?.args?.get("includeDetails")
+        )
+    }
+
+    @Test
+    fun `test List Tool toGeminiTools`() {
+        // Given
+        val propertiesSchema = JsonObject(
+            mapOf(
+            "query" to JsonPrimitive("string"),
+            "includeDetails" to JsonPrimitive(true)
+        )
+        )
+        val tools = listOf(
+            Tool(
+                toolId = "search_weather",
+                description = "Search for weather information",
+                argumentsSchema = Tool.ArgumentsSchema(
+                    propertiesSchema = propertiesSchema,
+                    requiredProperties = listOf("query")
+                )
+            ),
+            Tool(
+                toolId = "get_time",
+                description = "Get current time",
+                argumentsSchema = Tool.ArgumentsSchema(
+                    propertiesSchema = JsonObject(mapOf("timezone" to JsonPrimitive("string"))),
+                    requiredProperties = emptyList()
+                )
+            )
+        )
+
+        // When
+        val geminiTools = tools.toGeminiTools()
+
+        // Then
+        assertEquals(2, geminiTools.functionDeclarations?.size)
+
+        val weatherTool = geminiTools.functionDeclarations?.get(0)
+        assertEquals("search_weather", weatherTool?.name)
+        assertEquals("Search for weather information", weatherTool?.description)
+        assertEquals(JsonPrimitive("string"), weatherTool?.parameters?.properties?.get("query"))
+        assertEquals(
+            JsonPrimitive(true),
+            weatherTool?.parameters?.properties?.get("includeDetails")
+        )
+        assertEquals(listOf("query"), weatherTool?.parameters?.required)
+
+        val timeTool = geminiTools.functionDeclarations?.get(1)
+        assertEquals("get_time", timeTool?.name)
+        assertEquals("Get current time", timeTool?.description)
+        assertEquals(JsonPrimitive("string"), timeTool?.parameters?.properties?.get("timezone"))
+        assertEquals(emptyList(), timeTool?.parameters?.required)
+    }
+
+    @Test
+    fun `test createGenerateContentRequest with no tools and no system prompt`() {
+        // Given
+        val conversation = Conversation(
+            messages = listOf(
+                Message.UserMessage("Hello, AI!")
+            )
+        )
+
+        // When
+        val request = createGenerateContentRequest(
+            conversation = conversation,
+            systemPrompt = null,
+            tools = emptyList()
+        )
+
+        // Then
+        assertEquals(1, request.contents.size)
+        assertEquals("user", request.contents[0].role)
+        assertEquals("Hello, AI!", request.contents[0].parts[0].text)
+        assertNull(request.tools)
+        assertNull(request.systemInstruction)
+    }
+
+    @Test
+    fun `test createGenerateContentRequest with system prompt`() {
+        // Given
+        val conversation = Conversation(
+            messages = listOf(
+                Message.UserMessage("Hello, AI!")
+            )
+        )
+        val systemPrompt = "You are a helpful assistant."
+
+        // When
+        val request = createGenerateContentRequest(
+            conversation = conversation,
+            systemPrompt = systemPrompt,
+            tools = emptyList()
+        )
+
+        // Then
+        assertEquals(1, request.contents.size)
+        assertEquals("user", request.contents[0].role)
+        assertEquals("Hello, AI!", request.contents[0].parts[0].text)
+        assertNull(request.tools)
+        assertNotNull(request.systemInstruction)
+        assertEquals(systemPrompt, request.systemInstruction?.parts?.get(0)?.text)
+    }
+
+    @Test
+    fun `test createGenerateContentRequest with tools`() {
+        // Given
+        val conversation = Conversation(
+            messages = listOf(
+                Message.UserMessage("What's the weather?")
+            )
+        )
+        val tools = listOf(
+            Tool(
+                toolId = "search_weather",
+                description = "Search for weather information",
+                argumentsSchema = Tool.ArgumentsSchema(
+                    propertiesSchema = JsonObject(mapOf("location" to JsonPrimitive("string"))),
+                    requiredProperties = listOf("location")
+                )
+            )
+        )
+
+        // When
+        val request = createGenerateContentRequest(
+            conversation = conversation,
+            systemPrompt = null,
+            tools = tools
+        )
+
+        // Then
+        assertEquals(1, request.contents.size)
+        assertEquals("user", request.contents[0].role)
+        assertEquals("What's the weather?", request.contents[0].parts[0].text)
+        assertNotNull(request.tools)
+        assertEquals(1, request.tools?.size)
+        assertEquals(1, request.tools?.get(0)?.functionDeclarations?.size)
+        assertEquals("search_weather", request.tools?.get(0)?.functionDeclarations?.get(0)?.name)
+    }
+
+    @Test
+    fun `test GenerateContentResponse toConversationResponse with text response`() {
+        // Given
+        val response = GenerateContentResponse(
+            candidates = listOf(
+                Candidate(
+                    content = Content(
+                        parts = listOf(
+                            Part(text = "I'm an AI assistant.")
+                        )
+                    ),
+                    finishReason = "STOP"
+                )
+            )
+        )
+
+        // When
+        val conversationResponse = response.toConversationResponse()
+
+        // Then
+        assertEquals(1, conversationResponse.newMessages.size)
+        val message = conversationResponse.newMessages[0]
+        assertTrue(message is Message.AiMessage.AiTextMessage)
+        assertEquals("I'm an AI assistant.", (message as Message.AiMessage.AiTextMessage).text)
+    }
+
+    @Test
+    fun `test GenerateContentResponse toConversationResponse with function call`() {
+        // Given
+        val functionCall = FunctionCall(
+            name = "search_weather",
+            args = JsonObject(mapOf("location" to JsonPrimitive("New York")))
+        )
+        val response = GenerateContentResponse(
+            candidates = listOf(
+                Candidate(
+                    content = Content(
+                        parts = listOf(
+                            Part(functionCall = functionCall)
+                        )
+                    )
+                )
+            )
+        )
+
+        // When
+        val conversationResponse = response.toConversationResponse()
+
+        // Then
+        assertEquals(1, conversationResponse.newMessages.size)
+        val message = conversationResponse.newMessages[0]
+        assertTrue(message is Message.AiMessage.AiToolUse)
+        val toolUse = message as Message.AiMessage.AiToolUse
+        assertEquals("search_weather", toolUse.toolId)
+        assertEquals(JsonPrimitive("New York"), toolUse.argumentsSupplied["location"])
+    }
+
+    @Test
+    fun `test GenerateContentResponse toConversationResponse with multiple parts`() {
+        // Given
+        val response = GenerateContentResponse(
+            candidates = listOf(
+                Candidate(
+                    content = Content(
+                        parts = listOf(
+                            Part(text = "Here's the weather:"),
+                            Part(
+                                functionCall = FunctionCall(
+                                    name = "search_weather",
+                                    args = JsonObject(mapOf("location" to JsonPrimitive("New York")))
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        // When
+        val conversationResponse = response.toConversationResponse()
+
+        // Then
+        assertEquals(2, conversationResponse.newMessages.size)
+
+        val textMessage = conversationResponse.newMessages[0]
+        assertTrue(textMessage is Message.AiMessage.AiTextMessage)
+        assertEquals("Here's the weather:", (textMessage as Message.AiMessage.AiTextMessage).text)
+
+        val toolUseMessage = conversationResponse.newMessages[1]
+        assertTrue(toolUseMessage is Message.AiMessage.AiToolUse)
+        assertEquals("search_weather", (toolUseMessage).toolId)
+        assertEquals(
+            JsonPrimitive("New York"),
+            (toolUseMessage).argumentsSupplied["location"]
+        )
+    }
+
+    @Test
+    fun `test GenerateContentResponse toConversationResponse with empty or null parts`() {
+        // Given
+        val response = GenerateContentResponse(
+            candidates = listOf(
+                Candidate(
+                    content = Content(
+                        parts = listOf(
+                            Part() // Empty part with no text or function call
+                        )
+                    )
+                )
+            )
+        )
+
+        // When
+        val conversationResponse = response.toConversationResponse()
+
+        // Then
+        assertEquals(0, conversationResponse.newMessages.size)
+    }
+}


### PR DESCRIPTION
This PR wraps network calls made with Ktor so that any errors are bubbled up to the repository in a reasonable way (ex. using the SolenneResult type).

As a note: I created SolenneResult (influenced by Airbnb's [Async type in Mvrks](https://github.com/airbnb/mavericks/blob/09d84b051a0aacd14635a950659d0414a4170a5a/mvrx-common/src/main/java/com/airbnb/mvrx/Async.kt#L10)) as an alternative to Kotlin's Result type. SolenneResult is a sealed class between Success and Failure, so inspecting the type and finding it's a failure actually gets the compiler to cast it to a success from then on (something Kotlin's Result type doesn't do).