### PR TITLE
Add provider selector screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/App.kt
@@ -2,10 +2,10 @@ package com.duchastel.simon.solenne
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorScreen
+import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
-import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
-import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.internal.BackHandler
 import com.slack.circuit.foundation.rememberCircuitNavigator
@@ -16,7 +16,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 fun App(circuit: Circuit) {
     MaterialTheme {
         CircuitCompositionLocals(circuit) {
-            val backStack = rememberSaveableBackStack(root = ConversationListScreen)
+            val backStack = rememberSaveableBackStack(root = ModelProviderSelectorScreen)
             val navigator = rememberCircuitNavigator(backStack, onRootPop = {})
 
             // NavigableCircuitContent appears not to pop the backstack

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AIModelScope.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AIModelScope.kt
@@ -6,6 +6,43 @@ sealed interface AIModelScope {
     ) : AIModelScope
 }
 
-sealed interface AIModel {
-    data object Gemini : AIModel
+sealed interface AIModelProvider {
+    val scope: AIModelScope? // a scope if it's configured, null otherwise
+    val availableModels: List<AIModel>
+
+    data class Gemini(
+        override val scope: AIModelScope?,
+    ) : AIModelProvider {
+        override val availableModels: List<AIModel> = listOf(
+            AIModel("gemini-2.0-flash"),
+        )
+    }
+
+    data class OpenAI(
+        override val scope: AIModelScope?
+    ) : AIModelProvider {
+        override val availableModels: List<AIModel> = listOf()
+    }
+
+    data class Anthropic(
+        override val scope: AIModelScope?
+    ) : AIModelProvider {
+        override val availableModels: List<AIModel> = listOf()
+    }
+
+    data class DeepSeek(
+        override val scope: AIModelScope?
+    ) : AIModelProvider {
+        override val availableModels: List<AIModel> = listOf()
+    }
+
+    data class Grok(
+        override val scope: AIModelScope?
+    ) : AIModelProvider {
+        override val availableModels: List<AIModel> = listOf()
+    }
 }
+
+data class AIModel(
+    val name: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepository.kt
@@ -1,5 +1,7 @@
 package com.duchastel.simon.solenne.data.ai
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * A repository for chatting with the AI backend.
  *
@@ -7,6 +9,12 @@ package com.duchastel.simon.solenne.data.ai
  * and chats with the particular AI models.
  */
 interface AiChatRepository {
+
+    /**
+     * Gets a list of available AI models.
+     */
+    fun getAvailableModelsFlow(): Flow<List<AIModelProvider>>
+
     /**
      * Sends a text message as the user to a conversation.
      */

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/db/chat/InMemoryChatDb.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/db/chat/InMemoryChatDb.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
-import com.duchastel.simon.solenne.network.ai.gemini.Content
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/ApplicationGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/ApplicationGraph.kt
@@ -1,40 +1,11 @@
 package com.duchastel.simon.solenne.di
 
-import com.duchastel.simon.solenne.screens.chat.ChatPresenter
-import com.duchastel.simon.solenne.screens.conversationlist.ConversationListPresenter
-import com.slack.circuit.foundation.Circuit
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
-import dev.zacsweers.metro.Provides
-import dev.zacsweers.metro.SingleIn
-import com.duchastel.simon.solenne.screens.chat.ChatScreen
-import com.duchastel.simon.solenne.screens.chat.ChatUi
-import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
-import com.duchastel.simon.solenne.screens.conversationlist.ConversationListUi
 
 @DependencyGraph(AppScope::class)
-interface ApplicationGraph: DataProviders, DbProviders, NetworkProviders {
-    val circuit: Circuit
-
-    @SingleIn(AppScope::class)
-    @Provides
-    fun provideCircuit(
-        chatPresenterFactory: ChatPresenter.Factory,
-        conversationListPresenterFactory: ConversationListPresenter.Factory
-    ): Circuit {
-        return Circuit.Builder()
-            .addPresenter<ChatScreen, ChatScreen.State> { screen, navigator, _ ->
-                chatPresenterFactory.create(screen, navigator)
-            }
-            .addUi<ChatScreen, ChatScreen.State> { state, modifier ->
-                ChatUi(state, modifier)
-            }
-            .addPresenter<ConversationListScreen, ConversationListScreen.State> { _, navigator, _ ->
-                conversationListPresenterFactory.create(navigator)
-            }
-            .addUi<ConversationListScreen, ConversationListScreen.State> { state, modifier ->
-                ConversationListUi(state, modifier)
-            }
-            .build()
-    }
-}
+interface ApplicationGraph:
+    CircuitProviders,
+    DataProviders,
+    DbProviders,
+    NetworkProviders

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
@@ -1,0 +1,48 @@
+package com.duchastel.simon.solenne.di
+
+import com.duchastel.simon.solenne.screens.chat.ChatPresenter
+import com.duchastel.simon.solenne.screens.chat.ChatScreen
+import com.duchastel.simon.solenne.screens.chat.ChatUi
+import com.duchastel.simon.solenne.screens.conversationlist.ConversationListPresenter
+import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
+import com.duchastel.simon.solenne.screens.conversationlist.ConversationListUi
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorPresenter
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorScreen
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorUi
+import com.slack.circuit.foundation.Circuit
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+interface CircuitProviders {
+    val circuit: Circuit
+
+    @SingleIn(AppScope::class)
+    @Provides
+    fun provideCircuit(
+        chatPresenterFactory: ChatPresenter.Factory,
+        conversationListPresenterFactory: ConversationListPresenter.Factory,
+        modelProviderSelectorPresenterFactory: ModelProviderSelectorPresenter.Factory
+    ): Circuit {
+        return Circuit.Builder()
+            .addPresenter<ChatScreen, ChatScreen.State> { screen, navigator, _ ->
+                chatPresenterFactory.create(screen, navigator)
+            }
+            .addUi<ChatScreen, ChatScreen.State> { state, modifier ->
+                ChatUi(state, modifier)
+            }
+            .addPresenter<ConversationListScreen, ConversationListScreen.State> { _, navigator, _ ->
+                conversationListPresenterFactory.create(navigator)
+            }
+            .addUi<ConversationListScreen, ConversationListScreen.State> { state, modifier ->
+                ConversationListUi(state, modifier)
+            }
+            .addPresenter<ModelProviderSelectorScreen, ModelProviderSelectorScreen.State> { _, navigator, _ ->
+                modelProviderSelectorPresenterFactory.create(navigator)
+            }
+            .addUi<ModelProviderSelectorScreen, ModelProviderSelectorScreen.State> { state, modifier ->
+                ModelProviderSelectorUi(state, modifier)
+            }
+            .build()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelProviderSelectorPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelProviderSelectorPresenter.kt
@@ -1,0 +1,64 @@
+package com.duchastel.simon.solenne.screens.modelselector
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import com.duchastel.simon.solenne.data.ai.AIModelProvider
+import com.duchastel.simon.solenne.data.ai.AiChatRepository
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorScreen.Event
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.Inject
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+class ModelProviderSelectorPresenter @Inject constructor(
+    @Assisted private val navigator: Navigator,
+    private val aiChatRepository: AiChatRepository,
+) : Presenter<ModelProviderSelectorScreen.State> {
+
+    @Composable
+    override fun present(): ModelProviderSelectorScreen.State {
+        val providers by remember {
+            aiChatRepository.getAvailableModelsFlow()
+                .distinctUntilChanged()
+        }.collectAsState(persistentListOf())
+
+        val uiModels = providers
+            .map(AIModelProvider::toUiModel)
+            .plus(UiModelProvider.Other(name = null))
+            .toPersistentList()
+        return ModelProviderSelectorScreen.State(
+            models = uiModels,
+        ) { event ->
+            when (event) {
+                is Event.BackPressed -> {
+                    navigator.pop()
+                }
+                is Event.ModelSelected -> {
+                    // TODO - navigate to next screen
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(navigator: Navigator): ModelProviderSelectorPresenter
+    }
+}
+
+private fun AIModelProvider.toUiModel(): UiModelProvider {
+    return when (this) {
+        is AIModelProvider.OpenAI -> UiModelProvider.OpenAI
+        is AIModelProvider.Anthropic -> UiModelProvider.Anthropic
+        is AIModelProvider.DeepSeek -> UiModelProvider.DeepSeek
+        is AIModelProvider.Gemini -> UiModelProvider.Gemini
+        is AIModelProvider.Grok -> UiModelProvider.Grok
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelProviderSelectorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelProviderSelectorScreen.kt
@@ -1,0 +1,31 @@
+package com.duchastel.simon.solenne.screens.modelselector
+
+import androidx.compose.runtime.Immutable
+import com.duchastel.simon.solenne.parcel.Parcelize
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.PersistentList
+
+@Parcelize
+data object ModelProviderSelectorScreen : Screen {
+    @Immutable
+    data class State(
+        val models: PersistentList<UiModelProvider>,
+        val eventSink: (Event) -> Unit = {},
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data class ModelSelected(val modelProvider: UiModelProvider) : Event
+        data object BackPressed : Event
+    }
+}
+
+sealed interface UiModelProvider {
+    data object Gemini : UiModelProvider
+    data object OpenAI : UiModelProvider
+    data object Anthropic : UiModelProvider
+    data object DeepSeek : UiModelProvider
+    data object Grok : UiModelProvider
+    data class Other(val name: String?) : UiModelProvider // null if no name specified yet
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelSelectorUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelselector/ModelSelectorUi.kt
@@ -1,0 +1,75 @@
+package com.duchastel.simon.solenne.screens.modelselector
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.duchastel.simon.solenne.screens.modelselector.ModelProviderSelectorScreen.Event
+import com.duchastel.simon.solenne.screens.modelselector.UiModelProvider.DeepSeek
+import com.duchastel.simon.solenne.screens.modelselector.UiModelProvider.Gemini
+import com.duchastel.simon.solenne.screens.modelselector.UiModelProvider.OpenAI
+import com.duchastel.simon.solenne.screens.modelselector.UiModelProvider.Other
+import com.duchastel.simon.solenne.ui.components.BackButton
+import com.duchastel.simon.solenne.ui.components.ModelProviderButton
+import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ModelProviderSelectorUi(
+    state: ModelProviderSelectorScreen.State,
+    modifier: Modifier,
+) {
+    val eventSink = state.eventSink
+
+    Column(modifier = modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            BackButton(
+                onClick = { eventSink(Event.BackPressed) },
+                modifier = Modifier.padding(end = 16.dp)
+            )
+            Text("Select AI Model")
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).fillMaxWidth()
+        ) {
+            items(state.models) { modelInfo ->
+                ModelProviderButton(
+                    model = modelInfo,
+                    onModelSelected = { eventSink(Event.ModelSelected(modelInfo)) }
+                )
+                Divider()
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun ModelSelectorUi_Preview() {
+    val models = persistentListOf(
+        Gemini,
+        OpenAI,
+        DeepSeek,
+        Other("Custom provider")
+    )
+
+    ModelProviderSelectorUi(
+        modifier = Modifier,
+        state = ModelProviderSelectorScreen.State(
+            models = models,
+        )
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/ModelProviderButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/ModelProviderButton.kt
@@ -1,0 +1,37 @@
+package com.duchastel.simon.solenne.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.duchastel.simon.solenne.screens.modelselector.UiModelProvider
+
+@Composable
+fun ModelProviderButton(
+    model: UiModelProvider,
+    onModelSelected: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable { onModelSelected() },
+        elevation = 4.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier.weight(1f).padding(start = 8.dp),
+                text = model.toString(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add a screen for users to select an AI model provider (OpenAI, Anthropic, etc.)

This will be a part of a few flows:
- configure model flow (ie. add an OpenAI key, etc.)
- choose model for chat flow