### PR TITLE
Add basic 'View MCP Servers' screen

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/duchastel/simon/solenne/AndroidApplicationGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/duchastel/simon/solenne/AndroidApplicationGraph.kt
@@ -6,8 +6,4 @@ import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.createGraph
 
 @DependencyGraph(AppScope::class)
-interface AndroidApplicationGraph : ApplicationGraph {
-    companion object {
-        fun create(): AndroidApplicationGraph = createGraph()
-    }
-}
+interface AndroidApplicationGraph : ApplicationGraph

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
@@ -257,7 +257,17 @@ class McpRepositoryImpl(
         /**
          * Map of MCP Server to MCP Client
          */
-        private var mcpServers by mutableStateOf<List<McpServer>>(emptyList())
+        @OptIn(ExperimentalUuidApi::class)
+        private var mcpServers by mutableStateOf(listOf(
+            // TODO - remove this debug code
+            McpServer(
+                id = Uuid.random().toString(),
+                name = "Lifx",
+                connection = Connection.Sse(
+                    url = "http://localhost:3000"
+                ),
+            )
+        ))
 
         /**
          * Map of MCP Server to MCP Tools

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
@@ -264,7 +264,7 @@ class McpRepositoryImpl(
                 id = Uuid.random().toString(),
                 name = "Lifx",
                 connection = Connection.Sse(
-                    url = "http://localhost:3000"
+                    url = "http://10.0.2.2:3000"
                 ),
             )
         ))

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
@@ -6,6 +6,9 @@ import com.duchastel.simon.solenne.screens.chat.ChatUi
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListPresenter
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListUi
+import com.duchastel.simon.solenne.screens.mcplist.MCPListPresenter
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen
+import com.duchastel.simon.solenne.screens.mcplist.MCPListUi
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigPresenter
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigScreen
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigUi
@@ -27,6 +30,7 @@ interface CircuitProviders {
         conversationListPresenterFactory: ConversationListPresenter.Factory,
         modelProviderSelectorPresenterFactory: ModelProviderSelectorPresenter.Factory,
         modelProviderConfigPresenterFactory: ModelProviderConfigPresenter.Factory,
+        mcpListPresenterFactory: MCPListPresenter.Factory,
     ): Circuit {
         return Circuit.Builder()
             .addPresenter<ChatScreen, ChatScreen.State> { screen, navigator, _ ->
@@ -52,6 +56,12 @@ interface CircuitProviders {
             }
             .addUi<ModelProviderConfigScreen, ModelProviderConfigScreen.State> { state, modifier ->
                 ModelProviderConfigUi(state, modifier)
+            }
+            .addPresenter<MCPListScreen, MCPListScreen.State> { _, navigator, _ ->
+                mcpListPresenterFactory.create(navigator)
+            }
+            .addUi<MCPListScreen, MCPListScreen.State> { state, modifier ->
+                MCPListUi(state, modifier)
             }
             .build()
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
@@ -23,6 +23,7 @@ data class ChatScreen(
     sealed interface Event : CircuitUiEvent {
         data class TextInputChanged(val text: String): Event
         data class SendMessage(val text: String): Event
+        data object ToolsPressed : Event
         data object BackPressed : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
@@ -30,7 +30,7 @@ fun ChatUi(state: ChatScreen.State, modifier: Modifier) {
     val input = state.textInput
 
     Column(modifier = modifier.fillMaxSize()) {
-        Row {
+        Row(modifier = Modifier.fillMaxWidth()) {
             BackButton(
                 modifier = Modifier.padding(8.dp),
                 onClick = { eventSink(Event.BackPressed) },

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -37,6 +38,9 @@ fun ChatUi(state: ChatScreen.State, modifier: Modifier) {
             Modifier.weight(1f)
             Text("Chat with Gemini")
             Modifier.weight(1f)
+            Button(onClick = { eventSink(Event.ToolsPressed) }) {
+                Text("View Tools")
+            }
         }
         LazyColumn(
             modifier = Modifier.weight(1f).fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
@@ -1,0 +1,63 @@
+package com.duchastel.simon.solenne.screens.mcplist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import com.duchastel.simon.solenne.data.tools.McpRepository
+import com.duchastel.simon.solenne.data.tools.McpServerStatus
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.Event
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
+
+@SingleIn(AppScope::class)
+class MCPListPresenter @Inject constructor(
+    @Assisted private val navigator: Navigator,
+    private val mcpRepository: McpRepository,
+) : Presenter<MCPListScreen.State> {
+
+    @Composable
+    override fun present(): MCPListScreen.State {
+        val coroutineScope = rememberCoroutineScope()
+
+        val servers by mcpRepository.serverStatusFlow().collectAsState(initial = emptyList())
+
+        return MCPListScreen.State(
+            mcpServers = servers.map(McpServerStatus::toUiModel).toPersistentList(),
+        ) { event ->
+            when (event) {
+                is Event.BackPressed -> {
+                    navigator.pop()
+                }
+                is Event.ConnectToServer -> coroutineScope.launch {
+                    // TODO - handle and log the unexpected null case
+                    val server = servers.find { it.mcpServer.id == event.server.id } ?: return@launch
+                    mcpRepository.connect(server.mcpServer)
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(navigator: Navigator): MCPListPresenter
+    }
+}
+
+fun McpServerStatus.toUiModel(): UIMCPServer {
+    return UIMCPServer(
+        id = mcpServer.id,
+        name = mcpServer.name,
+        status = when (status) {
+            is McpServerStatus.Status.Connected -> UIMCPServer.Status.Connected
+            is McpServerStatus.Status.Offline -> UIMCPServer.Status.Disconnected
+        },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
@@ -17,7 +17,6 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 
-@SingleIn(AppScope::class)
 class MCPListPresenter @Inject constructor(
     @Assisted private val navigator: Navigator,
     private val mcpRepository: McpRepository,

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListScreen.kt
@@ -1,0 +1,33 @@
+package com.duchastel.simon.solenne.screens.mcplist
+
+import androidx.compose.runtime.Immutable
+import com.duchastel.simon.solenne.parcel.Parcelize
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.Screen
+import kotlinx.collections.immutable.PersistentList
+
+@Parcelize
+data object MCPListScreen : Screen {
+    @Immutable
+    data class State(
+        val mcpServers: PersistentList<UIMCPServer>,
+        val eventSink: (Event) -> Unit = {},
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data object BackPressed : Event
+        data class ConnectToServer(val server: UIMCPServer) : Event
+    }
+}
+
+data class UIMCPServer(
+    val id: String,
+    val name: String,
+    val status: Status
+) {
+    sealed interface Status {
+        data object Connected : Status
+        data object Disconnected : Status
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
@@ -1,0 +1,86 @@
+package com.duchastel.simon.solenne.screens.mcplist
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.duchastel.simon.solenne.data.tools.McpServer
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.Event
+import com.duchastel.simon.solenne.ui.components.BackButton
+import kotlinx.collections.immutable.persistentListOf
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun MCPListUi(state: MCPListScreen.State, modifier: Modifier) {
+    val eventSink = state.eventSink
+    val servers = state.mcpServers
+
+    Column(modifier = modifier.fillMaxSize()) {
+        Row {
+            BackButton(
+                modifier = Modifier.padding(8.dp),
+                onClick = { eventSink(Event.BackPressed) },
+            )
+            Modifier.weight(1f)
+            Text("MCP Servers")
+            Modifier.weight(1f)
+        }
+        LazyColumn(
+            modifier = Modifier.weight(1f).padding(8.dp)
+        ) {
+            items(servers) { server ->
+                MCPServerItem(
+                    server = server,
+                    onConnectClick = { eventSink(Event.ConnectToServer(server)) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MCPServerItem(
+    server: UIMCPServer,
+    onConnectClick: () -> Unit,
+) {
+    Row {
+        Text("Server: ${server.name} (${server.status})")
+
+        if (server.status == UIMCPServer.Status.Disconnected) {
+            Spacer(modifier = Modifier.width(8.dp))
+            TextButton(onClick = onConnectClick) {
+                Text("Connect")
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun MCPListUi_Preview() {
+    MCPListUi(
+        modifier = Modifier,
+        state = MCPListScreen.State(
+            mcpServers = persistentListOf(
+                UIMCPServer(
+                    "1",
+                    "Server 1",
+                    UIMCPServer.Status.Connected,
+                ),UIMCPServer(
+                    "2",
+                    "Server 2",
+                    UIMCPServer.Status.Disconnected,
+                ),
+            ),
+        )
+    )
+}

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenterTest.kt
@@ -1,11 +1,9 @@
 package com.duchastel.simon.solenne.screens.chat
 
 import com.duchastel.simon.solenne.data.chat.models.ChatMessage
-import com.duchastel.simon.solenne.data.tools.McpRepository
 import com.duchastel.simon.solenne.fakes.ChatMessagesFake
 import com.duchastel.simon.solenne.fakes.FakeAiChatRepository
 import com.duchastel.simon.solenne.fakes.FakeChatMessageRepository
-import com.duchastel.simon.solenne.fakes.FakeMcpRepository
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest
@@ -24,7 +22,6 @@ class ChatPresenterTest {
     private lateinit var navigator: FakeNavigator
     private lateinit var aiRepository: FakeAiChatRepository
     private lateinit var chatRepository: FakeChatMessageRepository
-    private lateinit var mcpRepository: McpRepository
     private lateinit var presenter: ChatPresenter
 
     @BeforeTest
@@ -34,14 +31,12 @@ class ChatPresenterTest {
             initialMessages = mapOf(CONVERSATION_ID to ChatMessagesFake.chatMessages),
         )
         chatRepository = FakeChatMessageRepository()
-        mcpRepository = FakeMcpRepository()
         navigator = FakeNavigator(screen)
         presenter = ChatPresenter(
             navigator = navigator,
             screen = screen,
             chatRepository = chatRepository,
             aiChatRepository = aiRepository,
-            mcpRepository = mcpRepository,
         )
     }
 
@@ -50,13 +45,13 @@ class ChatPresenterTest {
         presenter.test {
             val initial = awaitItem()
             assertEquals(
-                expected = 1, // add 1 for mcp server test message
+                expected = 0,
                 actual = initial.messages.size,
             )
 
             val withMessages = expectMostRecentItem()
             assertEquals(
-                expected = ChatMessagesFake.chatMessages.size + 1, // add 1 for mcp server test message
+                expected = ChatMessagesFake.chatMessages.size,
                 actual = withMessages.messages.size,
             )
         }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
@@ -1,0 +1,85 @@
+package com.duchastel.simon.solenne.screens.mcplist
+
+import com.duchastel.simon.solenne.data.tools.McpServer
+import com.duchastel.simon.solenne.data.tools.McpServerStatus
+import com.duchastel.simon.solenne.fakes.FakeMcpRepository
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MCPListPresenterTest {
+
+    private lateinit var navigator: FakeNavigator
+    private lateinit var mcpRepository: FakeMcpRepository
+    private lateinit var presenter: MCPListPresenter
+
+    @BeforeTest
+    fun setup() {
+        navigator = FakeNavigator(MCPListScreen)
+        mcpRepository = FakeMcpRepository()
+        presenter = MCPListPresenter(
+            navigator = navigator,
+            mcpRepository = mcpRepository,
+        )
+    }
+
+    @Test
+    fun `present - emits list of MCP servers`() = runTest {
+        mcpRepository.addServer(
+            name = "Connected Server",
+            connection = McpServer.Connection.Stdio("test command"),
+        ).apply {
+            mcpRepository.connect(this.mcpServer) // connect this server to test the connected status
+        }
+        mcpRepository.addServer(
+            name = "Disconnected Server",
+            connection = McpServer.Connection.Stdio("test command"),
+        )
+
+        presenter.test {
+            val state = expectMostRecentItem()
+            assertEquals(2, state.mcpServers.size)
+            assertEquals("Connected Server", state.mcpServers[0].name)
+            assertEquals(UIMCPServer.Status.Connected, state.mcpServers[0].status)
+            assertEquals("Disconnected Server", state.mcpServers[1].name)
+            assertEquals(UIMCPServer.Status.Disconnected, state.mcpServers[1].status)
+        }
+    }
+
+    @Test
+    fun `present - back press triggers navigation pop`() = runTest {
+        presenter.test {
+            val state = expectMostRecentItem()
+            val eventSink = state.eventSink
+
+            eventSink(MCPListScreen.Event.BackPressed)
+
+            navigator.awaitPop()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `present - connect to server calls repository connect`() = runTest {
+        mcpRepository.addServer(
+            name = "Test Server",
+            connection = McpServer.Connection.Stdio("test command"),
+        )
+
+        presenter.test {
+            val state = expectMostRecentItem()
+            val uiServer = state.mcpServers.first()
+
+            state.eventSink(MCPListScreen.Event.ConnectToServer(uiServer))
+
+            val updatedState = expectMostRecentItem()
+            val updatedServer = updatedState.mcpServers.first()
+            assertEquals(UIMCPServer.Status.Connected, updatedServer.status)
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
@@ -82,4 +82,41 @@ class MCPListPresenterTest {
             assertEquals(UIMCPServer.Status.Connected, updatedServer.status)
         }
     }
+
+    @Test
+    fun `toUiModel - correctly maps McpServerStatus to UIMCPServer`() = runTest {
+        // Test Connected status
+        val connectedServer = McpServer(
+            id = "test-id-1",
+            name = "Connected Test Server",
+            connection = McpServer.Connection.Stdio("test command")
+        )
+        val connectedStatus = McpServerStatus(
+            mcpServer = connectedServer,
+            status = McpServerStatus.Status.Connected,
+            tools = emptyList()
+        )
+
+        val connectedUiModel = connectedStatus.toUiModel()
+        assertEquals(connectedServer.id, connectedUiModel.id)
+        assertEquals(connectedServer.name, connectedUiModel.name)
+        assertEquals(UIMCPServer.Status.Connected, connectedUiModel.status)
+
+        // Test Offline status
+        val offlineServer = McpServer(
+            id = "test-id-2",
+            name = "Offline Test Server",
+            connection = McpServer.Connection.Stdio("test command")
+        )
+        val offlineStatus = McpServerStatus(
+            mcpServer = offlineServer,
+            status = McpServerStatus.Status.Offline,
+            tools = emptyList()
+        )
+
+        val offlineUiModel = offlineStatus.toUiModel()
+        assertEquals(offlineServer.id, offlineUiModel.id)
+        assertEquals(offlineServer.name, offlineUiModel.name)
+        assertEquals(UIMCPServer.Status.Disconnected, offlineUiModel.status)
+    }
 }


### PR DESCRIPTION
As the description says, add a screen that lists current MCP servers and their status with a "connect" button if the server is offline. Hard-code my LIFX server for now for testing.