### PR TITLE
Add 'Add MCP Server' screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/data/tools/McpRepositoryImpl.kt
@@ -257,17 +257,7 @@ class McpRepositoryImpl(
         /**
          * Map of MCP Server to MCP Client
          */
-        @OptIn(ExperimentalUuidApi::class)
-        private var mcpServers by mutableStateOf(listOf(
-            // TODO - remove this debug code
-            McpServer(
-                id = Uuid.random().toString(),
-                name = "Lifx",
-                connection = Connection.Sse(
-                    url = "http://10.0.2.2:3000"
-                ),
-            )
-        ))
+        private var mcpServers by mutableStateOf(listOf<McpServer>())
 
         /**
          * Map of MCP Server to MCP Tools

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
@@ -1,5 +1,8 @@
 package com.duchastel.simon.solenne.di
 
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPPresenter
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPUi
 import com.duchastel.simon.solenne.screens.chat.ChatPresenter
 import com.duchastel.simon.solenne.screens.chat.ChatScreen
 import com.duchastel.simon.solenne.screens.chat.ChatUi
@@ -31,6 +34,7 @@ interface CircuitProviders {
         modelProviderSelectorPresenterFactory: ModelProviderSelectorPresenter.Factory,
         modelProviderConfigPresenterFactory: ModelProviderConfigPresenter.Factory,
         mcpListPresenterFactory: MCPListPresenter.Factory,
+        addMCPPresenterFactory: AddMCPPresenter.Factory,
     ): Circuit {
         return Circuit.Builder()
             .addPresenter<ChatScreen, ChatScreen.State> { screen, navigator, _ ->
@@ -62,6 +66,12 @@ interface CircuitProviders {
             }
             .addUi<MCPListScreen, MCPListScreen.State> { state, modifier ->
                 MCPListUi(state, modifier)
+            }
+            .addPresenter<AddMCPScreen, AddMCPScreen.State> { _, navigator, _ ->
+                addMCPPresenterFactory.create(navigator)
+            }
+            .addUi<AddMCPScreen, AddMCPScreen.State> { state, modifier ->
+                AddMCPUi(state, modifier)
             }
             .build()
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPPresenter.kt
@@ -1,0 +1,67 @@
+package com.duchastel.simon.solenne.screens.addmcp
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.duchastel.simon.solenne.data.tools.McpRepository
+import com.duchastel.simon.solenne.data.tools.McpServer
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen.Event
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.launch
+
+class AddMCPPresenter @Inject constructor(
+    @Assisted private val navigator: Navigator,
+    private val mcpRepository: McpRepository,
+) : Presenter<AddMCPScreen.State> {
+
+    @Composable
+    override fun present(): AddMCPScreen.State {
+        val coroutineScope = rememberCoroutineScope()
+        var serverName by remember { mutableStateOf("") }
+        var serverUrl by remember { mutableStateOf("") }
+
+        val isSaveEnabled = serverName.isNotBlank() && serverUrl.isNotBlank()
+
+        return AddMCPScreen.State(
+            serverName = serverName,
+            serverUrl = serverUrl,
+            isSaveEnabled = isSaveEnabled,
+        ) { event ->
+            when (event) {
+                is Event.BackPressed -> {
+                    navigator.pop()
+                }
+
+                is Event.ServerNameChanged -> {
+                    serverName = event.name
+                }
+
+                is Event.ServerUrlChanged -> {
+                    serverUrl = event.url
+                }
+
+                is Event.SavePressed -> {
+                    if (isSaveEnabled) {
+                        coroutineScope.launch {
+                            val connection = McpServer.Connection.Sse(url = serverUrl)
+                            mcpRepository.addServer(serverName, connection)
+                            navigator.pop()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(navigator: Navigator): AddMCPPresenter
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPScreen.kt
@@ -1,0 +1,25 @@
+package com.duchastel.simon.solenne.screens.addmcp
+
+import androidx.compose.runtime.Immutable
+import com.duchastel.simon.solenne.parcel.Parcelize
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.Screen
+
+@Parcelize
+data object AddMCPScreen : Screen {
+    @Immutable
+    data class State(
+        val serverName: String = "",
+        val serverUrl: String = "",
+        val isSaveEnabled: Boolean = false,
+        val eventSink: (Event) -> Unit = {},
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data object BackPressed : Event
+        data class ServerNameChanged(val name: String) : Event
+        data class ServerUrlChanged(val url: String) : Event
+        data object SavePressed : Event
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPUi.kt
@@ -1,0 +1,77 @@
+package com.duchastel.simon.solenne.screens.addmcp
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen.Event
+import com.duchastel.simon.solenne.ui.components.BackButton
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun AddMCPUi(state: AddMCPScreen.State, modifier: Modifier) {
+    val eventSink = state.eventSink
+
+    Column(modifier = modifier.fillMaxSize().padding(16.dp)) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            BackButton(
+                modifier = Modifier.padding(8.dp),
+                onClick = { eventSink(Event.BackPressed) },
+            )
+            Modifier.weight(1f)
+            Text("Add MCP Server")
+            Modifier.weight(1f)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = state.serverName,
+            onValueChange = { eventSink(Event.ServerNameChanged(it)) },
+            label = { Text("Server Name") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = state.serverUrl,
+            onValueChange = { eventSink(Event.ServerUrlChanged(it)) },
+            label = { Text("Server URL") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { eventSink(Event.SavePressed) },
+            enabled = state.isSaveEnabled,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Save")
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun AddMCPUi_Preview() {
+    AddMCPUi(
+        modifier = Modifier,
+        state = AddMCPScreen.State(
+            serverName = "Test Server",
+            serverUrl = "http://localhost:3000",
+            isSaveEnabled = true
+        )
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenter.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import com.duchastel.simon.solenne.data.tools.McpRepository
 import com.duchastel.simon.solenne.data.tools.McpServerStatus
+import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen
 import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.Event
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
@@ -39,6 +40,9 @@ class MCPListPresenter @Inject constructor(
                     // TODO - handle and log the unexpected null case
                     val server = servers.find { it.mcpServer.id == event.server.id } ?: return@launch
                     mcpRepository.connect(server.mcpServer)
+                }
+                is Event.AddServerPressed -> {
+                    navigator.goTo(AddMCPScreen)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListScreen.kt
@@ -18,6 +18,7 @@ data object MCPListScreen : Screen {
     sealed interface Event : CircuitUiEvent {
         data object BackPressed : Event
         data class ConnectToServer(val server: UIMCPServer) : Event
+        data object AddServerPressed : Event
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
@@ -8,19 +8,23 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.duchastel.simon.solenne.data.tools.McpServer
 import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.Event
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.State
 import com.duchastel.simon.solenne.ui.components.BackButton
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
-fun MCPListUi(state: MCPListScreen.State, modifier: Modifier) {
+fun MCPListUi(state: State, modifier: Modifier) {
     val eventSink = state.eventSink
     val servers = state.mcpServers
 
@@ -43,6 +47,12 @@ fun MCPListUi(state: MCPListScreen.State, modifier: Modifier) {
                     onConnectClick = { eventSink(Event.ConnectToServer(server)) },
                 )
             }
+        }
+        FloatingActionButton(
+            onClick = { eventSink(Event.AddServerPressed) },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Icon(Icons.Default.Add, contentDescription = "Add Server")
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ChatNetworkMessageRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ChatNetworkMessageRepositoryImplTest.kt
@@ -6,8 +6,8 @@ import com.duchastel.simon.solenne.data.chat.ChatMessageRepositoryImpl
 import com.duchastel.simon.solenne.data.chat.models.MessageAuthor
 import com.duchastel.simon.solenne.db.chat.DbMessage
 import com.duchastel.simon.solenne.db.chat.DbMessageContent
-import com.duchastel.simon.solenne.fakes.FakeAiChatApi
-import com.duchastel.simon.solenne.fakes.FakeChatMessageDb
+import com.duchastel.simon.solenne.util.fakes.FakeAiChatApi
+import com.duchastel.simon.solenne.util.fakes.FakeChatMessageDb
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/data/ai/AiChatRepositoryImplTest.kt
@@ -6,11 +6,11 @@ import com.duchastel.simon.solenne.data.chat.ChatMessageRepositoryImpl
 import com.duchastel.simon.solenne.data.chat.models.MessageAuthor
 import com.duchastel.simon.solenne.db.chat.DbMessage
 import com.duchastel.simon.solenne.db.chat.DbMessageContent
-import com.duchastel.simon.solenne.fakes.FakeAiChatApi
-import com.duchastel.simon.solenne.fakes.FakeChatMessageDb
-import com.duchastel.simon.solenne.fakes.FAKE_AI_MODEL_SCOPE
+import com.duchastel.simon.solenne.util.fakes.FakeAiChatApi
+import com.duchastel.simon.solenne.util.fakes.FakeChatMessageDb
+import com.duchastel.simon.solenne.util.fakes.FAKE_AI_MODEL_SCOPE
 import com.duchastel.simon.solenne.data.tools.McpRepository
-import com.duchastel.simon.solenne.fakes.FakeMcpRepository
+import com.duchastel.simon.solenne.util.fakes.FakeMcpRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPPresenterTest.kt
@@ -1,0 +1,140 @@
+package com.duchastel.simon.solenne.screens.addmcp
+
+import com.duchastel.simon.solenne.data.tools.McpServer
+import com.duchastel.simon.solenne.util.expectNoNavigationEvents
+import com.duchastel.simon.solenne.util.fakes.FakeMcpRepository
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddMCPPresenterTest {
+
+    private lateinit var navigator: FakeNavigator
+    private lateinit var mcpRepository: FakeMcpRepository
+    private lateinit var presenter: AddMCPPresenter
+
+    @BeforeTest
+    fun setup() {
+        navigator = FakeNavigator(AddMCPScreen)
+        mcpRepository = FakeMcpRepository()
+        presenter = AddMCPPresenter(
+            navigator = navigator,
+            mcpRepository = mcpRepository,
+        )
+    }
+
+    @Test
+    fun `initial state - fields empty and save disabled`() = runTest {
+        presenter.test {
+            val state = expectMostRecentItem()
+            assertEquals("", state.serverName)
+            assertEquals("", state.serverUrl)
+            assertFalse(state.isSaveEnabled)
+        }
+    }
+
+    @Test
+    fun `serverName changed - updates state`() = runTest {
+        presenter.test {
+            val initialState = expectMostRecentItem()
+            initialState.eventSink(AddMCPScreen.Event.ServerNameChanged("Test Server"))
+
+            val updatedState = expectMostRecentItem()
+            assertEquals("Test Server", updatedState.serverName)
+            assertEquals("", updatedState.serverUrl)
+            assertFalse(updatedState.isSaveEnabled)
+        }
+    }
+
+    @Test
+    fun `serverUrl changed - updates state`() = runTest {
+        presenter.test {
+            val initialState = expectMostRecentItem()
+            initialState.eventSink(AddMCPScreen.Event.ServerUrlChanged("http://example.com"))
+
+            val updatedState = expectMostRecentItem()
+            assertEquals("", updatedState.serverName)
+            assertEquals("http://example.com", updatedState.serverUrl)
+            assertFalse(updatedState.isSaveEnabled)
+        }
+    }
+
+    @Test
+    fun `both fields filled - enables save button`() = runTest {
+        presenter.test {
+            val initialState = expectMostRecentItem()
+
+            initialState.eventSink(AddMCPScreen.Event.ServerNameChanged("Test Server"))
+            val nameState = expectMostRecentItem()
+
+            nameState.eventSink(AddMCPScreen.Event.ServerUrlChanged("http://example.com"))
+            val finalState = expectMostRecentItem()
+
+            assertEquals("Test Server", finalState.serverName)
+            assertEquals("http://example.com", finalState.serverUrl)
+            assertTrue(finalState.isSaveEnabled)
+        }
+    }
+
+    @Test
+    fun `back pressed - navigates back`() = runTest {
+        presenter.test {
+            val state = expectMostRecentItem()
+            state.eventSink(AddMCPScreen.Event.BackPressed)
+
+            navigator.awaitPop()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `save pressed - adds server and navigates back`() = runTest {
+        presenter.test {
+            val initialState = expectMostRecentItem()
+
+            // Fill out form
+            initialState.eventSink(AddMCPScreen.Event.ServerNameChanged("Test Server"))
+            val nameState = expectMostRecentItem()
+
+            nameState.eventSink(AddMCPScreen.Event.ServerUrlChanged("http://example.com"))
+            val readyState = expectMostRecentItem()
+
+            // Save the form
+            readyState.eventSink(AddMCPScreen.Event.SavePressed)
+
+            // Verify navigation happened
+            navigator.awaitPop()
+
+            // Check server was added with correct values
+            val servers = mcpRepository.getServers()
+            assertEquals(1, servers.size)
+            assertEquals("Test Server", servers[0].mcpServer.name)
+            assertEquals(
+                McpServer.Connection.Sse("http://example.com"),
+                servers[0].mcpServer.connection
+            )
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `save pressed - does nothing when not enabled`() = runTest {
+        presenter.test {
+            val initialState = expectMostRecentItem()
+            initialState.eventSink(AddMCPScreen.Event.SavePressed)
+
+            // No server should be added
+            assertTrue(mcpRepository.getServers().isEmpty())
+            navigator.expectNoNavigationEvents()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenterTest.kt
@@ -2,8 +2,8 @@ package com.duchastel.simon.solenne.screens.chat
 
 import com.duchastel.simon.solenne.data.chat.models.ChatMessage
 import com.duchastel.simon.solenne.fakes.ChatMessagesFake
-import com.duchastel.simon.solenne.fakes.FakeAiChatRepository
-import com.duchastel.simon.solenne.fakes.FakeChatMessageRepository
+import com.duchastel.simon.solenne.util.fakes.FakeAiChatRepository
+import com.duchastel.simon.solenne.util.fakes.FakeChatMessageRepository
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListPresenterTest.kt
@@ -1,21 +1,18 @@
 package com.duchastel.simon.solenne.screens.conversationlist
 
 import com.duchastel.simon.solenne.data.chat.models.ChatConversation
-import com.duchastel.simon.solenne.fakes.FakeChatMessageRepository
+import com.duchastel.simon.solenne.util.fakes.FakeChatMessageRepository
 import com.duchastel.simon.solenne.screens.chat.ChatScreen
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen.Event
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 
 class ConversationListPresenterTest {
 

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListPresenterTest.kt
@@ -2,14 +2,13 @@ package com.duchastel.simon.solenne.screens.mcplist
 
 import com.duchastel.simon.solenne.data.tools.McpServer
 import com.duchastel.simon.solenne.data.tools.McpServerStatus
-import com.duchastel.simon.solenne.fakes.FakeMcpRepository
+import com.duchastel.simon.solenne.util.fakes.FakeMcpRepository
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 class MCPListPresenterTest {
 

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/modelproviderconfig/ModelProviderConfigPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/modelproviderconfig/ModelProviderConfigPresenterTest.kt
@@ -2,7 +2,7 @@ package com.duchastel.simon.solenne.screens.modelproviderconfig
 
 import com.duchastel.simon.solenne.data.ai.AIModelProvider
 import com.duchastel.simon.solenne.data.ai.AIProviderConfig
-import com.duchastel.simon.solenne.fakes.FakeAiChatRepository
+import com.duchastel.simon.solenne.util.fakes.FakeAiChatRepository
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/modelproviderselector/ModelProviderSelectorPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/modelproviderselector/ModelProviderSelectorPresenterTest.kt
@@ -2,9 +2,7 @@ package com.duchastel.simon.solenne.screens.modelproviderselector
 
 import com.duchastel.simon.solenne.data.ai.AIModelProvider
 import com.duchastel.simon.solenne.data.ai.AIModelProviderStatus
-import com.duchastel.simon.solenne.fakes.FakeAiChatRepository
-import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen
-import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigPresenter
+import com.duchastel.simon.solenne.util.fakes.FakeAiChatRepository
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/NavigationTestUtils.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/NavigationTestUtils.kt
@@ -1,0 +1,14 @@
+package com.duchastel.simon.solenne.util
+
+import com.slack.circuit.test.FakeNavigator
+
+/**
+ * Asserts that the no navigation have occurred.
+ * Wraps the existing [FakeNavigator.expectNoPopEvents], [FakeNavigator.expectNoGoToEvents],
+ * and [FakeNavigator.expectNoResetRootEvents] for convenience.
+ */
+fun FakeNavigator.expectNoNavigationEvents() {
+    expectNoPopEvents()
+    expectNoGoToEvents()
+    expectNoResetRootEvents()
+}

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiChatApi.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiChatApi.kt
@@ -1,4 +1,4 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope
 import com.duchastel.simon.solenne.network.ai.AiChatApi

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiChatRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiChatRepository.kt
@@ -1,4 +1,4 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.data.ai.AIModelProvider
 import com.duchastel.simon.solenne.data.ai.AIModelProviderStatus

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiModelScope.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeAiModelScope.kt
@@ -1,4 +1,4 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.data.ai.AIModelScope
 import com.duchastel.simon.solenne.data.ai.AIModelScope.GeminiModelScope

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeChatMessageDb.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeChatMessageDb.kt
@@ -1,4 +1,4 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.db.chat.ChatMessageDb
 import com.duchastel.simon.solenne.db.chat.DbMessage

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeChatMessageRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeChatMessageRepository.kt
@@ -1,10 +1,11 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.data.chat.models.ChatMessage
 import com.duchastel.simon.solenne.data.chat.ChatMessageRepository
 import com.duchastel.simon.solenne.data.chat.models.ChatConversation
 import com.duchastel.simon.solenne.data.chat.models.MessageAuthor
 import com.duchastel.simon.solenne.data.tools.McpServer
+import com.duchastel.simon.solenne.fakes.ChatMessagesFake
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeMcpRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/util/fakes/FakeMcpRepository.kt
@@ -1,4 +1,4 @@
-package com.duchastel.simon.solenne.fakes
+package com.duchastel.simon.solenne.util.fakes
 
 import com.duchastel.simon.solenne.data.tools.CallToolResult
 import com.duchastel.simon.solenne.data.tools.McpRepository
@@ -23,6 +23,9 @@ internal class FakeMcpRepository(
     override fun serverStatusFlow(): Flow<List<McpServerStatus>> = _statuses
 
     private var nextId = 1
+
+    // Helper method for tests to get current servers
+    fun getServers(): List<McpServerStatus> = _statuses.value
 
     override suspend fun addServer(
         name: String,


### PR DESCRIPTION
Adds a basic "Add MCP server" screen for adding a new MCP server. This also removes the hack I had for testing where I hard-coded a connection to my local LIFX server.

I vibe-coded this with [Firebender](https://firebender.com) in 5 minutes (I'm on a work trip so busier than normal this week, but still wanted to make some progress on my app). It's pretty crazy that it got something decent out so quickly with very little manual effort on my part, allowing me to focus on higher-level app architecture!