### PR TITLE
Fix MCP List in Settings

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsPresenter.kt
@@ -2,6 +2,7 @@ package com.duchastel.simon.solenne.screens.settings
 
 import androidx.compose.runtime.Composable
 import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen
 import com.duchastel.simon.solenne.screens.modelproviderselector.ModelProviderSelectorScreen
 import com.duchastel.simon.solenne.screens.settings.SettingsScreen.Event
 import com.duchastel.simon.solenne.util.url.UrlOpener
@@ -29,7 +30,7 @@ class SettingsPresenter @Inject constructor(
                 }
 
                 is Event.ConfigureMcpPressed -> {
-                    navigator.goTo(AddMCPScreen)
+                    navigator.goTo(MCPListScreen)
                 }
 
                 is Event.ViewSourcePressed -> {

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BuyMeCoffeeFooter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BuyMeCoffeeFooter.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -15,9 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.ui.icons.coffeeIcon
@@ -40,7 +36,6 @@ fun BuyMeCoffeeFooter(
             painter = coffeeIcon(),
             contentDescription = null,
             modifier = Modifier.size(24.dp),
-            tint = Color(0xFF333333)
         )
         Spacer(modifier = Modifier.weight(1f))
         Text(

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsPresenterTest.kt
@@ -1,6 +1,6 @@
 package com.duchastel.simon.solenne.screens.settings
 
-import com.duchastel.simon.solenne.screens.addmcp.AddMCPScreen
+import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen
 import com.duchastel.simon.solenne.screens.modelproviderselector.ModelProviderSelectorScreen
 import com.duchastel.simon.solenne.util.fakes.FakeUrlOpener
 import com.slack.circuit.test.FakeNavigator
@@ -56,14 +56,14 @@ class SettingsPresenterTest {
     }
     
     @Test
-    fun `present - add MCP pressed event navigates to AddMCPScreen`() = runTest {
+    fun `present - configure MCP pressed event navigates to MCPListScreen`() = runTest {
         presenter.test {
             val state = expectMostRecentItem()
             val eventSink = state.eventSink
             
             eventSink(SettingsScreen.Event.ConfigureMcpPressed)
             
-            assertEquals(AddMCPScreen, navigator.awaitNextScreen())
+            assertEquals(MCPListScreen, navigator.awaitNextScreen())
             cancelAndConsumeRemainingEvents()
         }
     }


### PR DESCRIPTION
The settings menu option to configure MCP servers brings you to the list MCP screen. Before it brought you to the add MCP server screen, which isn't very useful since you couldn't see what MCP servers were connected.

I also fixed the "Buy me a coffee" text to have a better text color.