### PR TITLE
Refactor header into common component

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/App.kt
@@ -2,7 +2,9 @@ package com.duchastel.simon.solenne
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import com.duchastel.simon.solenne.screens.splash.SplashScreen
+import com.duchastel.simon.solenne.util.circuit.LocalNavigator
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
@@ -19,12 +21,14 @@ fun App(circuit: Circuit) {
             val backStack = rememberSaveableBackStack(root = SplashScreen)
             val navigator = rememberCircuitNavigator(backStack, onRootPop = {})
 
-            // NavigableCircuitContent appears not to pop the backstack
-            // unless we delegate to the navigator from the BackHandler
-            BackHandler {
-                navigator.pop()
+            CompositionLocalProvider(LocalNavigator provides navigator) {
+                // NavigableCircuitContent appears not to pop the backstack
+                // unless we delegate to the navigator from the BackHandler
+                BackHandler {
+                    navigator.pop()
+                }
+                NavigableCircuitContent(navigator, backStack)
             }
-            NavigableCircuitContent(navigator, backStack)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/di/CircuitProviders.kt
@@ -24,6 +24,9 @@ import com.duchastel.simon.solenne.screens.settings.SettingsUi
 import com.duchastel.simon.solenne.screens.splash.SplashPresenter
 import com.duchastel.simon.solenne.screens.splash.SplashScreen
 import com.duchastel.simon.solenne.screens.splash.SplashUi
+import com.duchastel.simon.solenne.screens.topbar.TopBarPresenter
+import com.duchastel.simon.solenne.screens.topbar.TopBarScreen
+import com.duchastel.simon.solenne.screens.topbar.TopBarUi
 import com.slack.circuit.foundation.Circuit
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Provides
@@ -43,6 +46,7 @@ interface CircuitProviders {
         addMCPPresenterFactory: AddMCPPresenter.Factory,
         settingsPresenterFactory: SettingsPresenter.Factory,
         splashPresenterFactory: SplashPresenter.Factory,
+        topBarPresenterFactory: TopBarPresenter.Factory,
     ): Circuit {
         return Circuit.Builder()
             .addPresenter<SplashScreen, SplashScreen.State> { _, navigator, _ ->
@@ -92,6 +96,12 @@ interface CircuitProviders {
             }
             .addUi<SettingsScreen, SettingsScreen.State> { state, modifier ->
                 SettingsUi(state, modifier)
+            }
+            .addPresenter<TopBarScreen, TopBarScreen.State> { screen, _, _ ->
+                topBarPresenterFactory.create(screen)
+            }
+            .addUi<TopBarScreen, TopBarScreen.State> { state, modifier ->
+                TopBarUi(state, modifier)
             }
             .build()
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/addmcp/AddMCPUi.kt
@@ -23,23 +23,11 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 fun AddMCPUi(state: AddMCPScreen.State, modifier: Modifier) {
     val eventSink = state.eventSink
 
-    SolenneScaffold(modifier = modifier) {
+    SolenneScaffold(
+        modifier = modifier,
+        title = "Add MCP Server",
+    ) {
         Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BackButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = { eventSink(Event.BackPressed) },
-                )
-                Spacer(Modifier.weight(1f))
-                Text("Add MCP Server")
-                Spacer(Modifier.weight(1f))
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
             OutlinedTextField(
                 value = state.serverName,
                 onValueChange = { eventSink(Event.ServerNameChanged(it)) },

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatPresenter.kt
@@ -56,9 +56,6 @@ class ChatPresenter @Inject constructor(
                 is BackPressed -> {
                     navigator.pop()
                 }
-                is ChatScreen.Event.Settings -> {
-                    navigator.goTo(SettingsScreen)
-                }
                 is SendMessage -> coroutineScope.launch {
                     textInput = ""
                     aiModelScope ?: return@launch

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatScreen.kt
@@ -23,7 +23,6 @@ data class ChatScreen(
     sealed interface Event : CircuitUiEvent {
         data class TextInputChanged(val text: String): Event
         data class SendMessage(val text: String): Event
-        data object Settings : Event
         data object BackPressed : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
@@ -1,25 +1,18 @@
 package com.duchastel.simon.solenne.screens.chat
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Button
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.data.chat.models.ChatMessage
 import com.duchastel.simon.solenne.fakes.ChatMessagesFake
 import com.duchastel.simon.solenne.screens.chat.ChatScreen.Event
 import com.duchastel.simon.solenne.screens.chat.ChatScreen.State
-import com.duchastel.simon.solenne.ui.components.BackButton
 import com.duchastel.simon.solenne.ui.components.ChatMessage
 import com.duchastel.simon.solenne.ui.components.MessageInput
 import com.duchastel.simon.solenne.ui.components.SolenneScaffold
@@ -33,40 +26,26 @@ fun ChatUi(state: State, modifier: Modifier) {
     val messages = state.messages
     val input = state.textInput
 
-    SolenneScaffold(modifier = modifier) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BackButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = { eventSink(Event.BackPressed) },
-                )
-                Spacer(Modifier.weight(1f))
-                Text("Chat with Gemini")
-                Spacer(Modifier.weight(1f))
-                Button(onClick = { eventSink(Event.Settings) }) {
-                    Text("Settings")
-                }
+    SolenneScaffold(
+        title = "Chat with Gemini",
+        modifier = modifier,
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            reverseLayout = true,
+            contentPadding = PaddingValues(vertical = 8.dp)
+        ) {
+            items(messages.asReversed()) { message ->
+                ChatMessage(message)
             }
-            LazyColumn(
-                modifier = Modifier.weight(1f).fillMaxWidth(),
-                reverseLayout = true,
-                contentPadding = PaddingValues(vertical = 8.dp)
-            ) {
-                items(messages.asReversed()) { message ->
-                    ChatMessage(message)
-                }
-            }
-            MessageInput(
-                input = input,
-                onInputChange = { newInput -> eventSink(Event.TextInputChanged(newInput)) },
-                onSend = { eventSink(Event.SendMessage(input)) },
-                sendEnabled = state.sendButtonEnabled,
-                modifier = Modifier.fillMaxWidth().padding(8.dp)
-            )
         }
+        MessageInput(
+            input = input,
+            onInputChange = { newInput -> eventSink(Event.TextInputChanged(newInput)) },
+            onSend = { eventSink(Event.SendMessage(input)) },
+            sendEnabled = state.sendButtonEnabled,
+            modifier = Modifier.fillMaxWidth().padding(8.dp)
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListPresenter.kt
@@ -7,8 +7,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.duchastel.simon.solenne.data.chat.ChatMessageRepository
 import com.duchastel.simon.solenne.screens.chat.ChatScreen
+import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen.Event
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen.Event.ConversationClicked
 import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen.Event.NewConversationClicked
+import com.duchastel.simon.solenne.screens.conversationlist.ConversationListScreen.Event.SettingsClicked
+import com.duchastel.simon.solenne.screens.settings.SettingsScreen
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.zacsweers.metro.Assisted
@@ -46,6 +49,9 @@ class ConversationListPresenter @Inject constructor(
                     coroutineScope.launch {
                         chatRepository.createNewConversation()
                     }
+                }
+                is SettingsClicked -> {
+                    navigator.goTo(SettingsScreen)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/conversationlist/ConversationListUi.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -19,7 +20,10 @@ fun ConversationListUi(state: ConversationListScreen.State, modifier: Modifier) 
     val eventSink = state.eventSink
     val conversations = state.conversations
 
-    SolenneScaffold(modifier = modifier) {
+    SolenneScaffold(
+        title = "Conversations",
+        modifier = modifier,
+    ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -40,6 +44,11 @@ fun ConversationListUi(state: ConversationListScreen.State, modifier: Modifier) 
                     }
                 ) {
                     Text("New Conversation")
+                }
+            }
+            item {
+                Button(onClick = { eventSink(Event.SettingsClicked) }) {
+                    Text("Settings")
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/mcplist/MCPListUi.kt
@@ -1,10 +1,8 @@
 package com.duchastel.simon.solenne.screens.mcplist
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -16,12 +14,10 @@ import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.Event
 import com.duchastel.simon.solenne.screens.mcplist.MCPListScreen.State
-import com.duchastel.simon.solenne.ui.components.BackButton
 import com.duchastel.simon.solenne.ui.components.SolenneScaffold
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -31,36 +27,25 @@ fun MCPListUi(state: State, modifier: Modifier) {
     val eventSink = state.eventSink
     val servers = state.mcpServers
 
-    SolenneScaffold(modifier = modifier) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BackButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = { eventSink(Event.BackPressed) },
+    SolenneScaffold(
+        title = "MCP Servers",
+        modifier = modifier,
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(8.dp)
+        ) {
+            items(servers) { server ->
+                MCPServerItem(
+                    server = server,
+                    onConnectClick = { eventSink(Event.ConnectToServer(server)) },
                 )
-                Spacer(Modifier.weight(1f))
-                Text("MCP Servers")
-                Spacer(Modifier.weight(1f))
             }
-            LazyColumn(
-                modifier = Modifier.weight(1f).padding(8.dp)
-            ) {
-                items(servers) { server ->
-                    MCPServerItem(
-                        server = server,
-                        onConnectClick = { eventSink(Event.ConnectToServer(server)) },
-                    )
-                }
-            }
-            FloatingActionButton(
-                onClick = { eventSink(Event.AddServerPressed) },
-                modifier = Modifier.padding(16.dp)
-            ) {
-                Icon(Icons.Default.Add, contentDescription = "Add Server")
-            }
+        }
+        FloatingActionButton(
+            onClick = { eventSink(Event.AddServerPressed) },
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Icon(Icons.Default.Add, contentDescription = "Add Server")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelproviderconfig/ModelProviderConfigUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelproviderconfig/ModelProviderConfigUi.kt
@@ -1,7 +1,6 @@
 package com.duchastel.simon.solenne.screens.modelproviderconfig
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,14 +10,12 @@ import androidx.compose.material.Button
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigScreen.Event
 import com.duchastel.simon.solenne.screens.modelproviderconfig.ModelProviderConfigScreen.State
 import com.duchastel.simon.solenne.screens.modelproviderselector.UiModelProvider
-import com.duchastel.simon.solenne.ui.components.BackButton
 import com.duchastel.simon.solenne.ui.components.SolenneScaffold
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -29,39 +26,29 @@ fun ModelProviderConfigUi(
 ) {
     val eventSink = state.eventSink
 
-    SolenneScaffold(modifier = modifier) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+    SolenneScaffold(
+        title = "Configure ${state.modelProvider}",
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp)
+        ) {
+            OutlinedTextField(
+                value = state.apiKey ?: "",
+                onValueChange = { eventSink(Event.ApiKeyChanged(it)) },
+                label = { Text("API Key") },
+                isError = state.apiKey?.isBlank() == true,
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = { eventSink(Event.SavePressed) },
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                BackButton(
-                    onClick = { eventSink(Event.BackPressed) },
-                    modifier = Modifier.padding(end = 16.dp)
-                )
-                Text("Configure ${state.modelProvider} API Key")
-            }
-
-            Column(
-                modifier = Modifier.weight(1f).fillMaxWidth().padding(16.dp)
-            ) {
-                OutlinedTextField(
-                    value = state.apiKey ?: "",
-                    onValueChange = { eventSink(Event.ApiKeyChanged(it)) },
-                    label = { Text("API Key") },
-                    isError = state.apiKey?.isBlank() == true,
-                    visualTransformation = PasswordVisualTransformation(),
-                    modifier = Modifier.fillMaxWidth(),
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = { eventSink(Event.SavePressed) },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text("Save")
-                }
+                Text("Save")
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelproviderselector/ModelSelectorUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/modelproviderselector/ModelSelectorUi.kt
@@ -1,21 +1,13 @@
 package com.duchastel.simon.solenne.screens.modelproviderselector
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Divider
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.screens.modelproviderselector.ModelProviderSelectorScreen.Event
 import com.duchastel.simon.solenne.screens.modelproviderselector.UiModelProvider.Gemini
-import com.duchastel.simon.solenne.ui.components.BackButton
 import com.duchastel.simon.solenne.ui.components.ModelProviderButton
 import com.duchastel.simon.solenne.ui.components.SolenneScaffold
 import kotlinx.collections.immutable.persistentListOf
@@ -28,29 +20,19 @@ fun ModelProviderSelectorUi(
 ) {
     val eventSink = state.eventSink
 
-    SolenneScaffold(modifier = modifier) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                BackButton(
-                    onClick = { eventSink(Event.BackPressed) },
-                    modifier = Modifier.padding(end = 16.dp)
+    SolenneScaffold(
+        title = "Select AI Model",
+        modifier = modifier,
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            items(state.models) { modelInfo ->
+                ModelProviderButton(
+                    model = modelInfo,
+                    onModelSelected = { eventSink(Event.ModelSelected(modelInfo)) }
                 )
-                Text("Select AI Model")
-            }
-
-            LazyColumn(
-                modifier = Modifier.weight(1f).fillMaxWidth()
-            ) {
-                items(state.models) { modelInfo ->
-                    ModelProviderButton(
-                        model = modelInfo,
-                        onModelSelected = { eventSink(Event.ModelSelected(modelInfo)) }
-                    )
-                    Divider()
-                }
+                Divider()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/settings/SettingsUi.kt
@@ -1,20 +1,16 @@
 package com.duchastel.simon.solenne.screens.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.screens.settings.SettingsScreen.Event
 import com.duchastel.simon.solenne.screens.settings.SettingsScreen.State
-import com.duchastel.simon.solenne.ui.components.BackButton
 import com.duchastel.simon.solenne.ui.components.BuyMeCoffeeFooter
 import com.duchastel.simon.solenne.ui.components.GithubSourceFooter
 import com.duchastel.simon.solenne.ui.components.SettingsRow
@@ -28,52 +24,41 @@ fun SettingsUi(
 ) {
     val eventSink = state.eventSink
 
-    SolenneScaffold(modifier = modifier) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BackButton(
-                    onClick = { eventSink(Event.BackPressed) },
-                    modifier = Modifier.padding(end = 16.dp)
-                )
-                Text("Settings")
-            }
+    SolenneScaffold(
+        title = "Settings",
+        modifier = modifier,
+    ) {
+        Column(modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+        ) {
+            SettingsRow(
+                Modifier.fillMaxWidth(),
+                text = "Configure AI Models",
+                onClick = { eventSink(Event.ConfigureAIModelPressed) },
+            )
 
-            Column(
-                modifier = Modifier.weight(1f)
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                SettingsRow(
-                    Modifier.fillMaxWidth(),
-                    text = "Configure AI Models",
-                    onClick = { eventSink(Event.ConfigureAIModelPressed) },
-                )
+            Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
+            SettingsRow(
+                modifier = Modifier.fillMaxWidth(),
+                text = "Configure MCP Servers",
+                onClick = { eventSink(Event.ConfigureMcpPressed) },
+            )
 
-                SettingsRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = "Configure MCP Servers",
-                    onClick = { eventSink(Event.ConfigureMcpPressed) },
-                )
+            Spacer(modifier = Modifier.weight(1f))
 
-                Spacer(modifier = Modifier.weight(1f))
+            BuyMeCoffeeFooter(
+                onClick = { eventSink(Event.BuyMeACoffeePressed) },
+                modifier = Modifier.fillMaxWidth()
+            )
 
-                BuyMeCoffeeFooter(
-                    onClick = { eventSink(Event.BuyMeACoffeePressed) },
-                    modifier = Modifier.fillMaxWidth()
-                )
+            Spacer(modifier = Modifier.height(16.dp))
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                GithubSourceFooter(
-                    onClick = { eventSink(Event.ViewSourcePressed) },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+            GithubSourceFooter(
+                onClick = { eventSink(Event.ViewSourcePressed) },
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/splash/SplashUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/splash/SplashUi.kt
@@ -12,13 +12,11 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun SplashUi(state: State, modifier: Modifier = Modifier) {
-    SolenneScaffold(modifier = modifier) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            CircularProgressIndicator()
-        }
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarPresenter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarPresenter.kt
@@ -1,0 +1,42 @@
+package com.duchastel.simon.solenne.screens.topbar
+
+import androidx.compose.runtime.Composable
+import com.duchastel.simon.solenne.screens.topbar.TopBarScreen.Event
+import com.duchastel.simon.solenne.util.circuit.LocalNavigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.Inject
+
+class TopBarPresenter @Inject constructor(
+    @Assisted private val screen: TopBarScreen
+) : Presenter<TopBarScreen.State> {
+
+    @Composable
+    override fun present(): TopBarScreen.State {
+        // since TopBar isn't created within the same
+        // NavigableCircuit instance, use a composition local navigator
+        // to navigate within the rest of the hierarchy
+        val navigator = LocalNavigator.current
+
+        val itemsInBackStack = navigator?.peekBackStack()?.size ?: 0
+        return TopBarScreen.State(
+            title = screen.title,
+            showBackButton = itemsInBackStack > 1, // backstack includes current screen
+            eventSink = { event ->
+                when (event) {
+                    is Event.BackPressed -> {
+                        navigator?.pop()
+                    }
+                }
+            }
+        )
+    }
+
+    @AssistedFactory
+    fun interface Factory {
+        fun create(
+            screen: TopBarScreen
+        ): TopBarPresenter
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarScreen.kt
@@ -1,24 +1,23 @@
-package com.duchastel.simon.solenne.screens.conversationlist
+package com.duchastel.simon.solenne.screens.topbar
 
 import androidx.compose.runtime.Immutable
 import com.duchastel.simon.solenne.parcel.Parcelize
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.Screen
-import kotlinx.collections.immutable.PersistentList
 
 @Parcelize
-data object ConversationListScreen: Screen {
-
+data class TopBarScreen(
+    val title: String,
+) : Screen {
     @Immutable
     data class State(
-        val conversations: PersistentList<String>,
+        val title: String,
+        val showBackButton: Boolean,
         val eventSink: (Event) -> Unit = {},
     ) : CircuitUiState
 
     sealed interface Event : CircuitUiEvent {
-        data class ConversationClicked(val conversationId: String) : Event
-        data object NewConversationClicked : Event
-        data object SettingsClicked : Event
+        data object BackPressed : Event
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarUi.kt
@@ -1,0 +1,68 @@
+package com.duchastel.simon.solenne.screens.topbar
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.duchastel.simon.solenne.screens.topbar.TopBarScreen.Event
+import com.duchastel.simon.solenne.screens.topbar.TopBarScreen.State
+import com.duchastel.simon.solenne.ui.components.BackButton
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Composable
+fun TopBarUi(
+    state: State,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (state.showBackButton) {
+            BackButton(
+                onClick = { state.eventSink(Event.BackPressed) },
+                modifier = Modifier.padding(8.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+
+        Spacer(Modifier.weight(1f))
+        Text(state.title)
+        Spacer(Modifier.weight(1f))
+
+        if (state.showBackButton) {
+            // add extra space at the end to balance out the back button
+            Spacer(modifier = Modifier.width(48.dp + 8.dp + 16.dp))
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun TopBarUi_ShowBackButton_Preview() {
+    TopBarUi(
+        state = State(
+            title = "Top Bar",
+            showBackButton = true,
+        )
+    )
+}
+
+@Preview
+@Composable
+internal fun TopBarUi_NoBackButton_Preview() {
+    TopBarUi(
+        state = State(
+            title = "Top Bar",
+            showBackButton = false,
+        )
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BackButton.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BackButton.kt
@@ -19,8 +19,7 @@ fun BackButton(
         imageVector = Icons.AutoMirrored.Default.ArrowBack,
         contentDescription = "Back",
         modifier = modifier
-            .size(48.dp)
+            .size(24.dp)
             .clickable(onClick = onClick)
-            .padding(12.dp)
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BuyMeCoffeeFooter.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/BuyMeCoffeeFooter.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -15,9 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.solenne.ui.icons.coffeeIcon

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/SettingsRow.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/SettingsRow.kt
@@ -8,7 +8,7 @@ import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,7 +32,7 @@ fun SettingsRow(
                 text = text,
                 modifier = Modifier.weight(1f)
             )
-            Icon(Icons.Default.ArrowForward, contentDescription = null)
+            Icon(Icons.AutoMirrored.Default.ArrowForward, contentDescription = null)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/SolenneScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/ui/components/SolenneScaffold.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.duchastel.simon.solenne.screens.topbar.TopBarScreen
+import com.slack.circuit.foundation.CircuitContent
 
 /**
  * A scaffold component that provides basic functionality for all screens, including edge-to-edge
@@ -15,12 +17,14 @@ import androidx.compose.ui.Modifier
 @Composable
 fun SolenneScaffold(
     modifier: Modifier = Modifier,
+    title: String,
     content: @Composable () -> Unit
 ) {
     Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .windowInsetsPadding(WindowInsets.safeDrawing),
+        topBar = { CircuitContent(TopBarScreen(title = title)) }
     ) {
         content()
     }

--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/util/circuit/Navigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/util/circuit/Navigation.kt
@@ -1,0 +1,6 @@
+package com.duchastel.simon.solenne.util.circuit
+
+import androidx.compose.runtime.compositionLocalOf
+import com.slack.circuit.runtime.Navigator
+
+val LocalNavigator = compositionLocalOf<Navigator?> { null }

--- a/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarPresenterTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/duchastel/simon/solenne/screens/topbar/TopBarPresenterTest.kt
@@ -1,0 +1,31 @@
+package com.duchastel.simon.solenne.screens.topbar
+
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TopBarPresenterTest {
+    companion object {
+        private const val TEST_TITLE = "Test Title"
+    }
+
+    private val navigator: FakeNavigator = FakeNavigator(TopBarScreen(TEST_TITLE))
+    private lateinit var presenter: TopBarPresenter
+
+    @BeforeTest
+    fun setup() {
+        val screen = TopBarScreen(TEST_TITLE)
+        presenter = TopBarPresenter(screen = screen)
+    }
+
+    @Test
+    fun `present - emits state with correct title`() = runTest {
+        presenter.test {
+            val state = awaitItem()
+            assertEquals(TEST_TITLE, state.title)
+        }
+    }
+}


### PR DESCRIPTION
I refactored the header into its own "TopBar" screen, which I added to the SolenneScaffold.

I'm not super happy with the units of decomposition in the TopBar. Since the TopBar is rendered separate from the NavigableCircuitContent block, it doesn't have access to the right navigator and thus I need to pass the original navigator in via a composition local to the presenter. This relies on an implementation detail of how Circuit works, since the presenter is in the same composable as the UI (but this might not necessarily be the case in the future).

In the future, I think I'll instead have all screens which want to take part in the SolenneScaffold pattern subclass a "SolenneScreenState" or something, and plumb the back press events into the SolenneScaffold more manually (rather than having the TopBar be a separate Screen entirely).