### PR TITLE
Fix layout in Chat UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/duchastel/simon/solenne/screens/chat/ChatUi.kt
@@ -1,5 +1,6 @@
 package com.duchastel.simon.solenne.screens.chat
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,22 +31,24 @@ fun ChatUi(state: State, modifier: Modifier) {
         title = "Chat with Gemini",
         modifier = modifier,
     ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            reverseLayout = true,
-            contentPadding = PaddingValues(vertical = 8.dp)
-        ) {
-            items(messages.asReversed()) { message ->
-                ChatMessage(message)
+        Column(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+                reverseLayout = true,
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(messages.asReversed()) { message ->
+                    ChatMessage(message)
+                }
             }
+            MessageInput(
+                input = input,
+                onInputChange = { newInput -> eventSink(Event.TextInputChanged(newInput)) },
+                onSend = { eventSink(Event.SendMessage(input)) },
+                sendEnabled = state.sendButtonEnabled,
+                modifier = Modifier.fillMaxWidth().padding(8.dp)
+            )
         }
-        MessageInput(
-            input = input,
-            onInputChange = { newInput -> eventSink(Event.TextInputChanged(newInput)) },
-            onSend = { eventSink(Event.SendMessage(input)) },
-            sendEnabled = state.sendButtonEnabled,
-            modifier = Modifier.fillMaxWidth().padding(8.dp)
-        )
     }
 }
 


### PR DESCRIPTION
When migrating to the shared header in #31 I messed up the layout in the ChatUI, so this PR fixes it.

| Before | After |
| -- | -- |
| <img width="313" alt="Screenshot 2025-05-22 at 10 34 18 AM" src="https://github.com/user-attachments/assets/8ab7b447-176b-4a05-8b62-1b1264a30647" /> | <img width="308" alt="Screenshot 2025-05-22 at 10 32 34 AM" src="https://github.com/user-attachments/assets/0c653194-6bda-4530-ba66-8845479c0d06" /> |


