### PR TITLE
Use forked modelcontextprotocol kotlin sdk repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run all tests
         run: ./gradlew allTest
         env:
-          GITHUB_ACTOR: ${{ simon-duchastel }}
+          GITHUB_ACTOR: simon-duchastel
           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
 
       - name: Upload test reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,6 +35,9 @@ jobs:
 
       - name: Run all tests
         run: ./gradlew allTest
+        env:
+          GITHUB_ACTOR: ${{ simon-duchastel }}
+          GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}
 
       - name: Upload test reports
         uses: actions/upload-artifact@v4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ compose-multiplatform = "1.7.3"
 circuit = "0.27.1"
 kotlin = "2.1.20"
 coroutines = "1.10.2"
-mcpKotlin = "0.4.0-local"
+mcpKotlin = "0.5.0"
 kotlinx-coroutines = "1.10.2"
 metro = "0.2.0"
 ktor = "3.1.2"
@@ -20,7 +20,7 @@ multiplatform-settings = "1.3.0"
 
 [libraries]
 circuit-test = { module = "com.slack.circuit:circuit-test", version.ref = "circuit" }
-mcp-kotlin = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcpKotlin" }
+mcp-kotlin = { module = "com.duchastel.simon.modelcontextprotocol.kotlin.sdk:kotlin-sdk", version.ref = "mcpKotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,13 @@ dependencyResolutionManagement {
         maven {
             url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
         }
+        maven {
+            url = uri("https://maven.pkg.github.com/simon-duchastel/modelcontextprotocol-kotlin-sdk")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
         mavenLocal()
     }
 }


### PR DESCRIPTION
Uses the fork https://github.com/simon-duchastel/modelcontextprotocol-kotlin-sdk of https://github.com/modelcontextprotocol/kotlin-sdk, since it doesn't support wasmJs and iOS. I need to have a remote-accessible (ie. published) in order for github actions and cloudflare pages to work. Until now I've been using a local maven repo.

Until https://github.com/modelcontextprotocol/kotlin-sdk/pull/81 is merged in, I'll need to keep using the fork in order for github actions to work.