### PR TITLE
Add error handling for opfs web db

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/com/duchastel/simon/solenne/db/WasmJsSqlDriverFactory.kt
+++ b/composeApp/src/wasmJsMain/kotlin/com/duchastel/simon/solenne/db/WasmJsSqlDriverFactory.kt
@@ -13,13 +13,9 @@ class WasmJsSqlDriverFactory : SqlDriverFactory {
     override suspend fun createSqlDriver(): SqlDriver {
         val webWorker = createSqlWorker()
         return WebWorkerDriver(webWorker).apply {
-            try {
-                val dbExists = checkIfDbExistsJs().await<JsBoolean>().toBoolean()
-                if (!dbExists) {
-                    Database.Schema.create(this@apply).await()
-                }
-            }catch (ex: Exception) {
-                println(ex)
+            val dbExists = checkIfDbExistsJs().await<JsBoolean>().toBoolean()
+            if (!dbExists) {
+                Database.Schema.create(this@apply).await()
             }
         }
     }
@@ -29,32 +25,15 @@ fun createSqlWorker(): Worker = js(
     """new Worker(new URL("sqlite.worker.js", import.meta.url))"""
 )
 
-val checkIfDbExistsJs: () -> Promise<JsBoolean> = js(
-    """
-    new Promise(function(resolve, reject) {
-        var request = indexedDB.open('database.db', 1);
-        request.onupgradeneeded = function(event) {
-            event.target.transaction.abort();  // avoid creating a new store if not needed
-        };
-        request.onsuccess = function(event) {
-            var db = event.target.result;
-            if (!db.objectStoreNames.contains('files')) {
-                resolve(false);
-                return;
-            }
-            var tx = db.transaction('files', 'readonly');
-            var store = tx.objectStore('files');
-            var getReq = store.get('sqlite.db');
-            getReq.onsuccess = function() {
-                resolve(getReq.result != undefined && getReq.result != null);
-            };
-            getReq.onerror = function() {
-                reject(getReq.error);
-            };
-        };
-        request.onerror = function(event) {
-            reject(request.error);
-        };
-    })
-    """
-)
+val checkIfDbExistsJs: () -> Promise<JsBoolean> = js("""
+  async function() {
+    try {
+      const storageManager = navigator.storage;
+      const root = await storageManager.getDirectory();
+      await root.getFileHandle("database.db", { create: false });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+""")

--- a/composeApp/src/wasmJsMain/resources/sqlite.worker.js
+++ b/composeApp/src/wasmJsMain/resources/sqlite.worker.js
@@ -1,60 +1,106 @@
-// Courtesy of @IlyaGulya:
-// https://github.com/IlyaGulya/TodoAppDecomposeMviKotlin/blob/fd6d535783f55bdf2ce5494768a0520acd27a7dd/web/src/jsMain/resources/sqlite.worker.js#L4
 importScripts("sqlite3.js");
 
- let db = null;
+let db = null;
 
- async function createDatabase() {
-   const sqlite3 = await sqlite3InitModule();
+async function createDatabase() {
+  const sqlite3 = await sqlite3InitModule();
 
-   db = new sqlite3.oo1.DB("file:database.db?vfs=opfs", "c");
- }
+  const existingData = await loadDatabaseFile();
+  if (existingData) {
+    const buffer = new Uint8Array(existingData);
+    db = new sqlite3.oo1.DB(buffer);
+    console.log("Loaded database from IndexedDB.");
+  } else {
+    db = new sqlite3.oo1.DB();
+    console.log("Created new empty database.");
+  }
+}
 
- function handleMessage() {
-   const data = this.data;
+function openIndexedDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open("database.db", 1);
+    request.onupgradeneeded = (event) => {
+      const db = event.target.result;
+      db.createObjectStore("files");
+    };
+    request.onsuccess = (event) => resolve(event.target.result);
+    request.onerror = (event) => reject(event.target.error);
+  });
+}
 
-   switch (data && data.action) {
-     case "exec":
-       if (!data["sql"]) {
-         throw new Error("exec: Missing query string");
-       }
+async function loadDatabaseFile() {
+  const idb = await openIndexedDB();
+  return new Promise((resolve, reject) => {
+    const tx = idb.transaction("files", "readonly");
+    const store = tx.objectStore("files");
+    const request = store.get("sqlite.db");
 
-       return postMessage({
-         id: data.id,
-         results: { values: db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" }) },
-       })
-     case "begin_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("BEGIN TRANSACTION;"),
-       })
-     case "end_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("END TRANSACTION;"),
-       })
-     case "rollback_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("ROLLBACK TRANSACTION;"),
-       })
-     default:
-       throw new Error(`Unsupported action: ${data && data.action}`);
-   }
- }
+    request.onsuccess = () => resolve(request.result || null);
+    request.onerror = () => reject(request.error);
+  });
+}
 
- function handleError(err) {
-   return postMessage({
-     id: this.data.id,
-     error: err,
-   });
- }
+async function saveDatabaseFile() {
+  const idb = await openIndexedDB();
+  const data = db.export();
+  return new Promise((resolve, reject) => {
+    const tx = idb.transaction("files", "readwrite");
+    const store = tx.objectStore("files");
+    const request = store.put(data, "sqlite.db");
 
- if (typeof importScripts === "function") {
-   db = null;
-   const sqlModuleReady = createDatabase();
-   self.onmessage = (event) => {
-     return sqlModuleReady.then(handleMessage.bind(event))
-     .catch(handleError.bind(event));
-   }
- }
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// Handle incoming messages
+async function handleMessage() {
+  const data = this.data;
+
+  switch (data && data.action) {
+    case "exec":
+      if (!data["sql"]) {
+        throw new Error("exec: Missing query string");
+      }
+      const results = db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" });
+      // Save DB after write queries
+      if (/^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|ALTER|BEGIN|END|COMMIT|ROLLBACK)/i.test(data.sql)) {
+        await saveDatabaseFile();
+      }
+      return postMessage({ id: data.id, results: { values: results } });
+
+    case "begin_transaction":
+      db.exec("BEGIN TRANSACTION;");
+      return postMessage({ id: data.id, results: null });
+
+    case "end_transaction":
+      db.exec("END TRANSACTION;");
+      await saveDatabaseFile();
+      return postMessage({ id: data.id, results: null });
+
+    case "rollback_transaction":
+      db.exec("ROLLBACK TRANSACTION;");
+      await saveDatabaseFile();
+      return postMessage({ id: data.id, results: null });
+
+    default:
+      throw new Error(`Unsupported action: ${data && data.action}`);
+  }
+}
+
+function handleError(err) {
+  return postMessage({
+    id: this.data.id,
+    error: err.toString(),
+  });
+}
+
+if (typeof importScripts === "function") {
+  db = null;
+  const sqlModuleReady = createDatabase();
+  self.onmessage = (event) => {
+    sqlModuleReady
+      .then(handleMessage.bind(event))
+      .catch(handleError.bind(event));
+  };
+}

--- a/composeApp/src/wasmJsMain/resources/sqlite.worker.js
+++ b/composeApp/src/wasmJsMain/resources/sqlite.worker.js
@@ -1,106 +1,60 @@
+// Courtesy of @IlyaGulya:
+// https://github.com/IlyaGulya/TodoAppDecomposeMviKotlin/blob/fd6d535783f55bdf2ce5494768a0520acd27a7dd/web/src/jsMain/resources/sqlite.worker.js#L4
 importScripts("sqlite3.js");
 
-let db = null;
+ let db = null;
 
-async function createDatabase() {
-  const sqlite3 = await sqlite3InitModule();
+ async function createDatabase() {
+   const sqlite3 = await sqlite3InitModule();
 
-  const existingData = await loadDatabaseFile();
-  if (existingData) {
-    const buffer = new Uint8Array(existingData);
-    db = new sqlite3.oo1.DB(buffer);
-    console.log("Loaded database from IndexedDB.");
-  } else {
-    db = new sqlite3.oo1.DB();
-    console.log("Created new empty database.");
-  }
-}
+   db = new sqlite3.oo1.DB("file:database.db?vfs=opfs", "c");
+ }
 
-function openIndexedDB() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open("database.db", 1);
-    request.onupgradeneeded = (event) => {
-      const db = event.target.result;
-      db.createObjectStore("files");
-    };
-    request.onsuccess = (event) => resolve(event.target.result);
-    request.onerror = (event) => reject(event.target.error);
-  });
-}
+ function handleMessage() {
+   const data = this.data;
 
-async function loadDatabaseFile() {
-  const idb = await openIndexedDB();
-  return new Promise((resolve, reject) => {
-    const tx = idb.transaction("files", "readonly");
-    const store = tx.objectStore("files");
-    const request = store.get("sqlite.db");
+   switch (data && data.action) {
+     case "exec":
+       if (!data["sql"]) {
+         throw new Error("exec: Missing query string");
+       }
 
-    request.onsuccess = () => resolve(request.result || null);
-    request.onerror = () => reject(request.error);
-  });
-}
+       return postMessage({
+         id: data.id,
+         results: { values: db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" }) },
+       })
+     case "begin_transaction":
+       return postMessage({
+         id: data.id,
+         results: db.exec("BEGIN TRANSACTION;"),
+       })
+     case "end_transaction":
+       return postMessage({
+         id: data.id,
+         results: db.exec("END TRANSACTION;"),
+       })
+     case "rollback_transaction":
+       return postMessage({
+         id: data.id,
+         results: db.exec("ROLLBACK TRANSACTION;"),
+       })
+     default:
+       throw new Error(`Unsupported action: ${data && data.action}`);
+   }
+ }
 
-async function saveDatabaseFile() {
-  const idb = await openIndexedDB();
-  const data = db.export();
-  return new Promise((resolve, reject) => {
-    const tx = idb.transaction("files", "readwrite");
-    const store = tx.objectStore("files");
-    const request = store.put(data, "sqlite.db");
+ function handleError(err) {
+   return postMessage({
+     id: this.data.id,
+     error: err,
+   });
+ }
 
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
-  });
-}
-
-// Handle incoming messages
-async function handleMessage() {
-  const data = this.data;
-
-  switch (data && data.action) {
-    case "exec":
-      if (!data["sql"]) {
-        throw new Error("exec: Missing query string");
-      }
-      const results = db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" });
-      // Save DB after write queries
-      if (/^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|ALTER|BEGIN|END|COMMIT|ROLLBACK)/i.test(data.sql)) {
-        await saveDatabaseFile();
-      }
-      return postMessage({ id: data.id, results: { values: results } });
-
-    case "begin_transaction":
-      db.exec("BEGIN TRANSACTION;");
-      return postMessage({ id: data.id, results: null });
-
-    case "end_transaction":
-      db.exec("END TRANSACTION;");
-      await saveDatabaseFile();
-      return postMessage({ id: data.id, results: null });
-
-    case "rollback_transaction":
-      db.exec("ROLLBACK TRANSACTION;");
-      await saveDatabaseFile();
-      return postMessage({ id: data.id, results: null });
-
-    default:
-      throw new Error(`Unsupported action: ${data && data.action}`);
-  }
-}
-
-function handleError(err) {
-  return postMessage({
-    id: this.data.id,
-    error: err.toString(),
-  });
-}
-
-if (typeof importScripts === "function") {
-  db = null;
-  const sqlModuleReady = createDatabase();
-  self.onmessage = (event) => {
-    sqlModuleReady
-      .then(handleMessage.bind(event))
-      .catch(handleError.bind(event));
-  };
-}
+ if (typeof importScripts === "function") {
+   db = null;
+   const sqlModuleReady = createDatabase();
+   self.onmessage = (event) => {
+     return sqlModuleReady.then(handleMessage.bind(event))
+     .catch(handleError.bind(event));
+   }
+ }

--- a/composeApp/src/wasmJsMain/resources/sqlite.worker.js
+++ b/composeApp/src/wasmJsMain/resources/sqlite.worker.js
@@ -1,60 +1,92 @@
 // Courtesy of @IlyaGulya:
 // https://github.com/IlyaGulya/TodoAppDecomposeMviKotlin/blob/fd6d535783f55bdf2ce5494768a0520acd27a7dd/web/src/jsMain/resources/sqlite.worker.js#L4
 importScripts("sqlite3.js");
+import initSqlJs from "sql.js";
 
- let db = null;
+let db = null;
 
- async function createDatabase() {
-   const sqlite3 = await sqlite3InitModule();
+async function createDatabase() {
+  const sqlite3 = await sqlite3InitModule();
 
-   db = new sqlite3.oo1.DB("file:database.db?vfs=opfs", "c");
- }
+  // Check if OPFS VFS is available, fallback to in-memory if not
+  if (!sqlite3.capi.sqlite3_vfs_find("opfs") || !sqlite3.oo1.OpfsDb) {
+    let SQL = await initSqlJs({ locateFile: file => '/sql-wasm.wasm' });
+    db = new SQL.Database();
+  }
 
- function handleMessage() {
-   const data = this.data;
+  try {
+    db = new sqlite3.oo1.OpfsDb("/database.db", "c");
+  } catch (error) {
+    // Handle OPFS-specific errors (locking, I/O, etc.)
+    console.error("Failed to create OPFS database:", error);
+    throw new Error(`Database creation failed: ${error.message}`);
+  }
+}
 
-   switch (data && data.action) {
-     case "exec":
-       if (!data["sql"]) {
-         throw new Error("exec: Missing query string");
-       }
+function handleMessage() {
+  const data = this.data;
 
-       return postMessage({
-         id: data.id,
-         results: { values: db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" }) },
-       })
-     case "begin_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("BEGIN TRANSACTION;"),
-       })
-     case "end_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("END TRANSACTION;"),
-       })
-     case "rollback_transaction":
-       return postMessage({
-         id: data.id,
-         results: db.exec("ROLLBACK TRANSACTION;"),
-       })
-     default:
-       throw new Error(`Unsupported action: ${data && data.action}`);
-   }
- }
+  try {
+    switch (data && data.action) {
+      case "exec":
+        if (!data["sql"]) {
+          throw new Error("exec: Missing query string");
+        }
 
- function handleError(err) {
-   return postMessage({
-     id: this.data.id,
-     error: err,
-   });
- }
+        return postMessage({
+          id: data.id,
+          results: { values: db.exec({ sql: data.sql, bind: data.params, returnValue: "resultRows" }) },
+        });
 
- if (typeof importScripts === "function") {
-   db = null;
-   const sqlModuleReady = createDatabase();
-   self.onmessage = (event) => {
-     return sqlModuleReady.then(handleMessage.bind(event))
-     .catch(handleError.bind(event));
-   }
- }
+      case "begin_transaction":
+        return postMessage({
+          id: data.id,
+          results: db.exec("BEGIN TRANSACTION;"),
+        });
+
+      case "end_transaction":
+        return postMessage({
+          id: data.id,
+          results: db.exec("END TRANSACTION;"),
+        });
+
+      case "rollback_transaction":
+        return postMessage({
+          id: data.id,
+          results: db.exec("ROLLBACK TRANSACTION;"),
+        });
+
+      default:
+        throw new Error(`Unsupported action: ${data && data.action}`);
+    }
+  } catch (error) {
+    // Better error handling for OPFS-specific issues
+    return postMessage({
+      id: data.id,
+      error: {
+        message: error.message,
+        // OPFS I/O errors might indicate locking issues
+        isLockingError: error.message.includes("I/O") || error.message.includes("lock")
+      }
+    });
+  }
+}
+
+function handleError(err) {
+  return postMessage({
+    id: this.data.id,
+    error: {
+      message: err.message,
+      stack: err.stack
+    }
+  });
+}
+
+if (typeof importScripts === "function") {
+  db = null;
+  const sqlModuleReady = createDatabase();
+  self.onmessage = (event) => {
+    return sqlModuleReady.then(handleMessage.bind(event))
+    .catch(handleError.bind(event));
+  }
+}


### PR DESCRIPTION
The web DB doesn't always have access to [opfs](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) (the API used to persist the db in the browser), in which case we should fallback to using an in-memory sqlite db.