### PR TITLE
Only run tests on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Run Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
To avoid spending too much on Github actions, I'll only run tests on PR for now. Eventually it may be worth it to run the tests before deploying just to be sure main doesn't get broken from concurrent merges.